### PR TITLE
Fixed type checks to use isAssignableFrom instead of equals

### DIFF
--- a/client_libraries/java/src/main/java/org/eclipse/tahu/message/model/DataSetDataType.java
+++ b/client_libraries/java/src/main/java/org/eclipse/tahu/message/model/DataSetDataType.java
@@ -51,7 +51,7 @@ public enum DataSetDataType {
 	}
 	
 	public void checkType(Object value) throws SparkplugInvalidTypeException {
-		if (value != null && !value.getClass().equals(clazz)) {
+		if (value != null && !clazz.isAssignableFrom(value.getClass())) {
 			throw new SparkplugInvalidTypeException(value.getClass());
 		}
 	}

--- a/client_libraries/java/src/main/java/org/eclipse/tahu/message/model/MetricDataType.java
+++ b/client_libraries/java/src/main/java/org/eclipse/tahu/message/model/MetricDataType.java
@@ -62,7 +62,7 @@ public enum MetricDataType {
 	}
 	
 	public void checkType(Object value) throws SparkplugInvalidTypeException {
-		if (value != null && !value.getClass().equals(clazz)) {
+		if (value != null && !clazz.isAssignableFrom(value.getClass())) {
 			logger.warn("Failed type check - " + clazz + " != " + ((value != null) ? value.getClass().toString() : "null"));
 			throw new SparkplugInvalidTypeException(value.getClass());
 		}

--- a/client_libraries/java/src/main/java/org/eclipse/tahu/message/model/ParameterDataType.java
+++ b/client_libraries/java/src/main/java/org/eclipse/tahu/message/model/ParameterDataType.java
@@ -55,7 +55,7 @@ public enum ParameterDataType {
 	}
 	
 	public void checkType(Object value) throws SparkplugInvalidTypeException {
-		if (value != null && !value.getClass().equals(clazz)) {
+		if (value != null && !clazz.isAssignableFrom(value.getClass())) {
 			logger.warn("Failed type check - " + clazz + " != " + value.getClass().toString());
 			throw new SparkplugInvalidTypeException(value.getClass());
 		}

--- a/client_libraries/java/src/main/java/org/eclipse/tahu/message/model/PropertyDataType.java
+++ b/client_libraries/java/src/main/java/org/eclipse/tahu/message/model/PropertyDataType.java
@@ -60,7 +60,7 @@ public enum PropertyDataType {
 	}
 	
 	public void checkType(Object value) throws SparkplugInvalidTypeException {
-		if (value != null && !value.getClass().equals(clazz)) {
+		if (value != null && !clazz.isAssignableFrom(value.getClass())) {
 			if(clazz == List.class && value instanceof List) {
 				// Allow List subclasses
 			} else {


### PR DESCRIPTION
I've modified the checkType methods to allow for subclasses by using the .isAssignableFrom() method instead of .equals() when performing the check.