### PR TITLE
Added constructor to pass in Map to PropertySetBuilder

### DIFF
--- a/client_libraries/java/src/main/java/org/eclipse/tahu/message/model/PropertySet.java
+++ b/client_libraries/java/src/main/java/org/eclipse/tahu/message/model/PropertySet.java
@@ -31,7 +31,7 @@ public class PropertySet implements Map<String, PropertyValue> {
 	private Map<String, PropertyValue> map;
 	
 	public PropertySet() {
-		this.map = new HashMap<String, PropertyValue>();
+		this.map = new HashMap<>();
 	}
 	
 	private PropertySet(Map<String, PropertyValue> propertyMap) {
@@ -141,11 +141,15 @@ public class PropertySet implements Map<String, PropertyValue> {
 		private Map<String, PropertyValue> propertyMap;
 		
 		public PropertySetBuilder() {
-			this.propertyMap = new HashMap<String, PropertyValue>();
+			this.propertyMap = new HashMap<>();
+		}
+		
+		public PropertySetBuilder(Map<String, PropertyValue> propertyMap) {
+			this.propertyMap = propertyMap;
 		}
 		
 		public PropertySetBuilder(PropertySet propertySet) throws SparkplugInvalidTypeException {
-			this.propertyMap = new HashMap<String, PropertyValue>();
+			this.propertyMap = new HashMap<>();
 			for (String name : propertySet.getNames()) {
 				PropertyValue value = propertySet.getPropertyValue(name);
 				propertyMap.put(name, new PropertyValue(value.getType(), value.getValue()));

--- a/sparkplug_b/stand_alone_examples/java_records/src/main/java/org/eclipse/tahu/SparkplugRecordsExample.java
+++ b/sparkplug_b/stand_alone_examples/java_records/src/main/java/org/eclipse/tahu/SparkplugRecordsExample.java
@@ -12,6 +12,7 @@ import static org.eclipse.tahu.message.model.MetricDataType.String;
 
 import java.util.Date;
 import java.util.Random;
+import java.util.TreeMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
@@ -146,21 +147,21 @@ public class SparkplugRecordsExample implements MqttCallbackExtended {
 		// Metric properties = Record fields
 		return new MetricBuilder(type, String, null)
 				.timestamp(timestamp)
-				.properties(new PropertySetBuilder()
+				.properties(new PropertySetBuilder(new TreeMap<>()) // TreeMap for natural ordering of the fields
 						.addProperty("intField", new PropertyValue(PropertyDataType.PropertySet,
-								new PropertySetBuilder()
+								new PropertySetBuilder(new TreeMap<>())
 										.addProperty("fieldValue",
 												new PropertyValue(PropertyDataType.Int32, random.nextInt()))
 										.createPropertySet()))
 						.addProperty("fltField",
 								new PropertyValue(PropertyDataType.PropertySet,
-										new PropertySetBuilder()
+										new PropertySetBuilder(new TreeMap<>())
 												.addProperty("fieldValue",
 														new PropertyValue(PropertyDataType.Float, random.nextFloat()))
 												.createPropertySet()))
 						.addProperty("strField",
 								new PropertyValue(PropertyDataType.PropertySet,
-										new PropertySetBuilder()
+										new PropertySetBuilder(new TreeMap<>())
 												.addProperty("fieldValue",
 														new PropertyValue(PropertyDataType.String, newUUID()))
 												.createPropertySet()))


### PR DESCRIPTION
- Updated the PropertySet.java class to include a PropertySetBuilder constructor that allowed a Map to be passed.
- Updated java_records example to use TreeMap for natural ordering of keys within the PropertySet.