### PR TITLE
Modified encoder/decoder to support empty metric name when aliasing is used

### DIFF
--- a/client_libraries/java/src/main/java/org/eclipse/tahu/message/SparkplugBPayloadDecoder.java
+++ b/client_libraries/java/src/main/java/org/eclipse/tahu/message/SparkplugBPayloadDecoder.java
@@ -94,26 +94,28 @@ public class SparkplugBPayloadDecoder implements PayloadDecoder<SparkplugBPayloa
 		MetricDataType dataType = MetricDataType.fromInteger((protoMetric.getDatatype()));
 
 		// Build and return the Metric
-		return new MetricBuilder(protoMetric.getName(), dataType, getMetricValue(protoMetric))
-				.isHistorical(
-						protoMetric.hasIsHistorical() ? protoMetric.getIsHistorical() : null)
-				.isTransient(protoMetric
-						.hasIsTransient() ? protoMetric.getIsTransient() : null)
-				.timestamp(protoMetric.hasTimestamp() ? new Date(protoMetric.getTimestamp()) : null)
-				.alias(protoMetric.hasAlias() ? protoMetric.getAlias() : null)
-				.metaData(protoMetric.hasMetadata()
-						? new MetaDataBuilder().contentType(protoMetric.getMetadata().getContentType())
-								.size(protoMetric.getMetadata().getSize()).seq(protoMetric.getMetadata().getSeq())
-								.fileName(protoMetric.getMetadata().getFileName())
-								.fileType(protoMetric.getMetadata().getFileType())
-								.md5(protoMetric.getMetadata().getMd5())
-								.description(protoMetric.getMetadata().getDescription()).createMetaData()
-						: null)
-				.properties(protoMetric.hasProperties()
-						? new PropertySetBuilder().addProperties(convertProperties(protoMetric.getProperties()))
-								.createPropertySet()
-						: null)
-				.createMetric();
+		return new MetricBuilder(protoMetric.hasName() ? protoMetric.getName() : null, dataType,
+				getMetricValue(protoMetric))
+						.isHistorical(protoMetric.hasIsHistorical() ? protoMetric.getIsHistorical() : null)
+						.isTransient(
+								protoMetric.hasIsTransient() ? protoMetric.getIsTransient() : null)
+						.timestamp(protoMetric
+								.hasTimestamp() ? new Date(protoMetric.getTimestamp()) : null)
+						.alias(protoMetric.hasAlias() ? protoMetric.getAlias() : null)
+						.metaData(protoMetric.hasMetadata()
+								? new MetaDataBuilder().contentType(protoMetric.getMetadata().getContentType())
+										.size(protoMetric.getMetadata().getSize())
+										.seq(protoMetric.getMetadata().getSeq())
+										.fileName(protoMetric.getMetadata().getFileName())
+										.fileType(protoMetric.getMetadata().getFileType())
+										.md5(protoMetric.getMetadata().getMd5())
+										.description(protoMetric.getMetadata().getDescription()).createMetaData()
+								: null)
+						.properties(protoMetric.hasProperties()
+								? new PropertySetBuilder().addProperties(convertProperties(protoMetric.getProperties()))
+										.createPropertySet()
+								: null)
+						.createMetric();
 	}
 
 	private Map<String, PropertyValue> convertProperties(SparkplugBProto.Payload.PropertySet decodedPropSet)

--- a/client_libraries/java/src/main/java/org/eclipse/tahu/message/SparkplugBPayloadEncoder.java
+++ b/client_libraries/java/src/main/java/org/eclipse/tahu/message/SparkplugBPayloadEncoder.java
@@ -97,6 +97,9 @@ public class SparkplugBPayloadEncoder implements PayloadEncoder<SparkplugBPayloa
 		// Set the name, data type, and value
 		if (metric.hasName()) {
 			builder.setName(metric.getName());
+		} else {
+			// name is an empty String by default and must be cleared
+			builder.clearName();
 		}
 
 		// Set the alias

--- a/sparkplug_b/sparkplug_b.proto
+++ b/sparkplug_b/sparkplug_b.proto
@@ -80,7 +80,7 @@ message Payload {
         }
 
         optional string version         = 1;          // The version of the Template to prevent mismatches
-        repeated Metric metrics         = 2;          // Each includes the name of the metric, the datatype of the member, and optionally contains a value
+        repeated Metric metrics         = 2;          // Each metric includes a name, datatype, and optionally a value
         repeated Parameter parameters   = 3;
         optional string template_ref    = 4;          // Reference to a template if this is extending a Template or an instance - must exist if an instance
         optional bool is_definition     = 5;

--- a/sparkplug_b/sparkplug_b.proto
+++ b/sparkplug_b/sparkplug_b.proto
@@ -80,7 +80,7 @@ message Payload {
         }
 
         optional string version         = 1;          // The version of the Template to prevent mismatches
-        repeated Metric metrics         = 2;          // Each metric is the name of the metric and the datatype of the member but does not contain a value
+        repeated Metric metrics         = 2;          // Each includes the name of the metric, the datatype of the member, and optionally contains a value
         repeated Parameter parameters   = 3;
         optional string template_ref    = 4;          // Reference to a template if this is extending a Template or an instance - must exist if an instance
         optional bool is_definition     = 5;


### PR DESCRIPTION
String values default to empty Strings in Protobuf vs null values. As a result when a metric name is truly null the encoder should clear the name which results in hasName() returning false. Then in the decoder before building the new metric the hasName() method should be called to know whether or not the Metric's name value should be false or not.