### PR TITLE
bugFix: options is not defined in sparkplug B client publishDeviceDeath

### DIFF
--- a/client_libraries/javascript/sparkplug-client/index.js
+++ b/client_libraries/javascript/sparkplug-client/index.js
@@ -259,7 +259,7 @@ function SparkplugClient(config) {
     };
 
     // Publishes Node BIRTH certificates for the edge node
-    this.publishDeviceDeath = function(deviceId, payload) {
+    this.publishDeviceDeath = function(deviceId, payload, options) {
         var topic = version + "/" + groupId + "/DDEATH/" + edgeNode + "/" + deviceId;
         // Add seq number
         addSeqNumber(payload);


### PR DESCRIPTION
In the sparkplug-client:

When using publishDeviceDeath, we get a options not defined error (used in the maybeCompressPayload function). 

I added options as an input to the publishDeviceDeath function to fix.