### PR TITLE
Remove System.out.println(metric) call on metric deserialization

### DIFF
--- a/client_libraries/java/src/main/java/org/eclipse/tahu/json/MetricDeserializer.java
+++ b/client_libraries/java/src/main/java/org/eclipse/tahu/json/MetricDeserializer.java
@@ -49,7 +49,6 @@ public class MetricDeserializer extends StdDeserializer<Metric> implements Resol
 			throws IOException, JsonProcessingException {
 
 		Metric metric = (Metric) defaultDeserializer.deserialize(parser, ctxt);
-		System.out.println(metric);
 
 		// Check if the data type is a File
 		if (metric.getDataType().equals(MetricDataType.File)) {


### PR DESCRIPTION
Remove System.out.println(metric) call on metric deserialization.

Signed-off-by: Nathan Davenport <nathan.davenport@hotmail.com>