### PR TITLE
Update sparkplugbpayload.js

### DIFF
--- a/client_libraries/javascript/sparkplug-payload/lib/sparkplugbpayload.js
+++ b/client_libraries/javascript/sparkplug-payload/lib/sparkplugbpayload.js
@@ -65,10 +65,10 @@
             case 3: // Int32
             case 5: // UInt8
             case 6: // UInt32
+            case 7: // UInt32
                 object.intValue = value;
                 break;
             case 4: // Int64
-            case 7: // UInt32
             case 8: // UInt64
             case 13: // DataTime
                 object.longValue = value;
@@ -113,9 +113,9 @@
             case 3: // Int32
             case 5: // UInt8
             case 6: // UInt32
+            case 7: // UInt32
                 return object.intValue;
             case 4: // Int64
-            case 7: // UInt32
             case 8: // UInt64
             case 13: // DataTime
                 return object.longValue;
@@ -222,6 +222,8 @@
                 return "Boolean";
             case 12:
                 return "String";
+            case 13:
+                return "DateTime";
             case 14:
                 return "Text";
             case 15:


### PR DESCRIPTION
Moved UInt32 into inttype defintion to prevent unecessary cast to UInt64.
Added Datetime to decodeType as field is missing from decoded payload.