### PR TITLE
Updated sparkplugbpayload.js

### DIFF
--- a/client_libraries/javascript/sparkplug-payload/lib/sparkplugbpayload.js
+++ b/client_libraries/javascript/sparkplug-payload/lib/sparkplugbpayload.js
@@ -64,11 +64,11 @@
             case 2: // Int16
             case 3: // Int32
             case 5: // UInt8
-            case 6: // UInt32
+            case 6: // UInt16
+            case 7: // UInt32
                 object.intValue = value;
                 break;
             case 4: // Int64
-            case 7: // UInt32
             case 8: // UInt64
             case 13: // DataTime
                 object.longValue = value;
@@ -112,10 +112,10 @@
             case 2: // Int16
             case 3: // Int32
             case 5: // UInt8
-            case 6: // UInt32
+            case 6: // UInt16
+            case 7: // UInt32
                 return object.intValue;
             case 4: // Int64
-            case 7: // UInt32
             case 8: // UInt64
             case 13: // DataTime
                 return object.longValue;
@@ -222,6 +222,8 @@
                 return "Boolean";
             case 12:
                 return "String";
+	    case 13:
+		return "DateTime";
             case 14:
                 return "Text";
             case 15:


### PR DESCRIPTION
In setValue() and getValue(): Moved UInt32 to intValue conversion to
prevent unnecessary casting to long.
In decodeType() added Datetime as decoded payloads are missing this
field.

Signed-off-by: Rikki Coles <r.j.coles@sheffield.ac.uk>