### PR TITLE
Update sparkplugbpayload.js

### DIFF
--- a/client_libraries/javascript/sparkplug-payload/lib/sparkplugbpayload.js
+++ b/client_libraries/javascript/sparkplug-payload/lib/sparkplugbpayload.js
@@ -663,7 +663,7 @@
         }
 
         if (protoMetric.hasOwnProperty("alias")) {
-            metric.alias = protoMetric.alias;
+            metric.alias = protoMetric.alias.toNumber();
         }
 
         if (protoMetric.hasOwnProperty("isHistorical")) {


### PR DESCRIPTION
When decoding, the alias of the metric is shown as "Long" and additional conversion has to be carried out on client side.

My proposal is to get it as a number. Or is there another good reason why to return the alias as Long?