### PR TITLE
Creation of sparkplug-payload node-red node

### DIFF
--- a/client_libraries/javascript/node-red-contrib-sparkplug-payload/README.md
+++ b/client_libraries/javascript/node-red-contrib-sparkplug-payload/README.md
@@ -1,0 +1,21 @@
+node-red-contrib-sparkplug-payload
+=========
+
+A node that provides tools for encoding and decoding payload objects and 
+strings using the [Sparkplug Google Protocol Buffer Schema](https://www.eclipse.org/tahu/spec/Sparkplug%20Topic%20Namespace%20and%20State%20ManagementV2.2-with%20appendix%20B%20format%20-%20Eclipse.pdf).
+
+This node is designed to facilitate the creation of your own Sparkplug nodes in
+ node red for adding data consumers for dashboarding or for implementing your 
+ own Sparkplug client using the built in MQTT node.
+
+## Installation
+
+  npm install node-red-contrib-sparkplug-payload
+
+## Usage
+
+Simply hook up the input to a source of Sparkplug formatted JSON strings or 
+objects and the encoded protobuf will be provided at the output.
+
+Similarly if the input is hooked up to a source of protobufs encoded in the 
+Sparkplug format, a decoded payload object will be provided at the output.

--- a/client_libraries/javascript/node-red-contrib-sparkplug-payload/package.json
+++ b/client_libraries/javascript/node-red-contrib-sparkplug-payload/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "node-red-contrib-sparkplug-payload",
+  "version": "1.0.0",
+  "description": "A node that provides tools for encoding and decoding payload objects and strings using the Sparkplug Google Protocol Buffer Schema",
+  "main": "sparkplug-payload.js",
+  "author": "Rikki Coles <r.coles@amrc.co.uk> (https://www.amrc.co.uk)",
+  "license": "EPL-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/eclipse/tahu.git"
+  },
+  "bugs": {
+    "url": "https://github.com/eclipse/tahu/issues"
+  },
+  "homepage": "https://github.com/eclipse/tahu",
+  "dependencies": {
+    "sparkplug-payload": "^1.0.1"
+  },
+  "keywords": [
+    "tahu",
+    "mqtt",
+    "sparkplug",
+    "node-red"
+  ],
+  "node-red": {
+    "nodes": {
+      "sparkplug-payload": "sparkplug-payload.js"
+    }
+  },
+  "files":[
+    "package.json",
+    "README.md",
+    "sparkplug-payload.html",
+    "sparkplug-payload.js"
+  ]
+}

--- a/client_libraries/javascript/node-red-contrib-sparkplug-payload/sparkplug-payload.html
+++ b/client_libraries/javascript/node-red-contrib-sparkplug-payload/sparkplug-payload.html
@@ -1,0 +1,26 @@
+<script type="text/javascript">
+    RED.nodes.registerType('sparkplug-payload',{
+        category: 'function',
+        color: '#C0DEED',
+        defaults: {
+            name: {value:""}
+        },
+        inputs:1,
+        outputs:1,
+        icon: "hash.svg",
+        label: function() {
+            return this.name||"sparkplug-payload";
+        }
+    });
+</script>
+
+<script type="text/html" data-template-name="sparkplug-payload">
+    <div class="form-row">
+        <label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+        <input type="text" id="node-input-name" placeholder="Name">
+    </div>
+</script>
+
+<script type="text/html" data-help-name="sparkplug-payload">
+    <p>A node that converts JSON payloads in Sparkplug structure to protobuf encoded binaries or vice versa.</p>
+</script>

--- a/client_libraries/javascript/node-red-contrib-sparkplug-payload/sparkplug-payload.js
+++ b/client_libraries/javascript/node-red-contrib-sparkplug-payload/sparkplug-payload.js
@@ -1,0 +1,34 @@
+const sparkplug = require("sparkplug-payload");
+const Payload = sparkplug.get("spBv1.0");
+
+module.exports = (RED) => {
+    function TranslatePayloadNode(config) {
+        RED.nodes.createNode(this, config);
+        let node = this;
+        let newPayload;
+        node.on('input', (msg) => {
+            if (typeof (msg.payload === "string")) {
+                try { // Check if JSON string and parse
+                    msg.payload = JSON.parse(msg.payload);
+                } catch {
+                    // Payload wasn't a JSON string
+                }
+            }
+
+            if (Buffer.isBuffer(msg.payload)) {// Payload is a protobuf
+                newPayload = Payload.decodePayload(msg.payload);
+
+            } else { // Payload might be an object
+                try {
+                    newPayload = Payload.encodePayload(msg.payload);
+
+                } catch (e) { // Payload wasn't a valid object
+                    this.error(e);
+                }
+            }
+            msg.payload = newPayload;
+            node.send(msg);
+        })
+    }
+    RED.nodes.registerType("sparkplug-payload", TranslatePayloadNode);
+}


### PR DESCRIPTION
For our project I created a node-red node to allow us to encode/decode sparkplug payloads.

I wanted to contribute this to the tahu project in case others found it useful. It is not uploaded to npm.

It depends on the sparkplug-payload javascript library.