### PR TITLE
fix: error in not filling in username and password

### DIFF
--- a/client_libraries/javascript/node-red-contrib-sparkplug/sparkplug/sparkplug.js
+++ b/client_libraries/javascript/node-red-contrib-sparkplug/sparkplug/sparkplug.js
@@ -23,8 +23,8 @@ module.exports = function(RED) {
             cacheEnabled = config.enablecache == "true",
             sparkPlugConfig = {
                 'serverUrl' : config.broker + ":" + config.port,
-                'username' : username,
-                'password' : password,
+                'username' : username ?? '',
+                'password' : password ?? '',
                 'groupId' : config.groupid,
                 'edgeNode' : config.edgenode,
                 'clientId' : config.clientid,


### PR DESCRIPTION
`sparkplug-client` needs `username` and `password` attributes to work normally. 

However, in the `node-red` extension node, the default behavior of not filling in username and password is to provide `undefined` to JS module, which will throw an exception and cannot instantiate the `sparkplug-client` object normally.