### PR TITLE
javascript/sparkplug-client: Support passing callback in stop function

### DIFF
--- a/javascript/core/sparkplug-client/index.js
+++ b/javascript/core/sparkplug-client/index.js
@@ -327,13 +327,13 @@ var SparkplugClient = /** @class */ (function (_super) {
         this.client.publish(topic, this.encodePayload(this.maybeCompressPayload(payload, options)));
         this.messageAlert("published", topic, payload);
     };
-    SparkplugClient.prototype.stop = function () {
+    SparkplugClient.prototype.stop = function (cb) {
         logger.debug("publishDeath: " + this.publishDeath);
         if (this.publishDeath) {
             // Publish the DEATH certificate
             this.publishNDeath(this.client);
         }
-        this.client.end();
+        this.client.end(cb);
     };
     // Configures and connects the client
     SparkplugClient.prototype.init = function () {

--- a/javascript/core/sparkplug-client/index.ts
+++ b/javascript/core/sparkplug-client/index.ts
@@ -346,13 +346,13 @@ class SparkplugClient extends events.EventEmitter {
         this.messageAlert("published", topic, payload);
     }
 
-    stop() {
+    stop(cb?: (err: Error) => void) {
         logger.debug("publishDeath: " + this.publishDeath);
         if (this.publishDeath) {
             // Publish the DEATH certificate
             this.publishNDeath(this.client);
         }
-        this.client.end();
+        this.client.end(cb);
     }
 
     // Configures and connects the client


### PR DESCRIPTION
This commit allows passing through the callback in the stop function to mqtt client .end function
This allows you to wait until the client ends and respond to it like the mqtt client library

ps: CLA should be correctly signed now