### PR TITLE
Added protection from deadlock during disconnect if retry connect completes

### DIFF
--- a/java/lib/core/src/main/java/org/eclipse/tahu/mqtt/TahuClient.java
+++ b/java/lib/core/src/main/java/org/eclipse/tahu/mqtt/TahuClient.java
@@ -1090,6 +1090,15 @@ public class TahuClient implements MqttCallbackExtended {
 
 	@Override
 	public void connectComplete(boolean reconnect, String serverURI) {
+		
+		// Check if we are in the process of disconnecting
+		if (disconnectInProgress) {
+			logger.warn("Ignoring connect complete to {}, disconnect in progress", serverURI);
+			// This potentially prevents a deadlock situation upon synchronizing on the clientLock below if a disconnect
+			// is in progress and waiting on the client.disconnect() call
+			return;
+		}
+		
 		synchronized (clientLock) {
 			if (reconnect) {
 				logger.debug("{}: SUCCESSFULLY RECONNECTED to {}", getClientId(), getMqttServerUrl());


### PR DESCRIPTION
Added some code to protect from a deadlock in the case where a "retry connect" completes during an attempted disconnect.  The connect complete will be ignored.

Signed-off-by: Chad Kienle <chad.kienle@gmail.com>