### PR TITLE
Fix payload:metrics:datatype type defrinition error in sparkplug_b.json

### DIFF
--- a/sparkplug_b/sparkplug_b.json
+++ b/sparkplug_b/sparkplug_b.json
@@ -95,7 +95,7 @@
                 "name" : { "type" : "string" },
                 "alias" : { "type" : "integer" },
                 "timestamp" : { "type" : "integer" },
-                "datatype" : { "type" : "string" },
+                "datatype" : { "type" : "integer" },
                 "isHistorical" : { "type" : "boolean" },
                 "isTransient" : { "type" : "boolean" },
                 "metadata" : { "$ref" : "#/definitions/metadata" },


### PR DESCRIPTION
The 'payload:metrics:datatype' is correctly defined as an 'uint32' in the 'sparkplug_b.proto' definition, however it is incorrectly defined as a 'string' in the 'sparkplug_b.json' file.

Note: It is possible the error happen when the 'datatype' historically was changed to be ENUM driven.