### PR TITLE
Minor fixes for toString method

### DIFF
--- a/java/lib/core/src/main/java/org/eclipse/tahu/message/model/SparkplugBPayloadMap.java
+++ b/java/lib/core/src/main/java/org/eclipse/tahu/message/model/SparkplugBPayloadMap.java
@@ -265,8 +265,8 @@ public class SparkplugBPayloadMap extends SparkplugBPayload {
 	@Override
 	public String toString() {
 		StringBuilder builder = new StringBuilder();
-		builder.append("SparkplugBPayload [timestamp=");
-		builder.append(super.getTimestamp());
+		builder.append("SparkplugBPayloadMap [timestamp=");
+		builder.append(super.getTimestamp() != null ? super.getTimestamp().getTime() : "null");
 		builder.append(", metrics=");
 		builder.append(getMetrics());
 		builder.append(", seq=");


### PR DESCRIPTION
Fixed the class name in the SparkplugBPayloadMap toString() method and changed the timestamp to align with SparkplugBPayload.