### PR TITLE
Added missing MetricDataType (by alias) to MetricDataTypeMap

### DIFF
--- a/java/lib/core/src/main/java/org/eclipse/tahu/model/MetricMap.java
+++ b/java/lib/core/src/main/java/org/eclipse/tahu/model/MetricMap.java
@@ -74,6 +74,7 @@ public class MetricMap {
 			if (alias != null) {
 				metricNameToAliasMap.put(metricName, alias);
 				aliasToMetricNameMap.put(alias, metricName);
+				metricDataTypeMap.addMetricDataType(alias, metricDataType);
 			}
 			metricDataTypeMap.addMetricDataType(metricName, metricDataType);
 		}


### PR DESCRIPTION
Added missing add statement to make sure the MetricDataTypeMap has contains the entry for the aliased type.