### PR TITLE
Upticked versions of js libraries sparkplug-payload to 1.0.2, sparkplug-client to 3.2.3

### DIFF
--- a/javascript/core/sparkplug-client/README.md
+++ b/javascript/core/sparkplug-client/README.md
@@ -432,14 +432,15 @@ client.on('close', function () {
         ping rescheduling within the client.
 * 3.2.1 Updated License and repo links, cleaned up logging.
 * 3.2.2 Bug Fixes
+* 3.2.3 Bug Fixes, added typescript
 
 ## License
 
-Copyright (c) 2016-2018 Cirrus Link Solutions
+Copyright (c) 2016-2023 Cirrus Link Solutions and others
 
 All rights reserved. This program and the accompanying materials
 are made available under the terms of the Eclipse Public License v1.0
 which accompanies this distribution, and is available at
 http://www.eclipse.org/legal/epl-v10.html
 
-Contributors: Cirrus Link Solutions
+Contributors: Cirrus Link Solutions and others

--- a/javascript/core/sparkplug-client/package-lock.json
+++ b/javascript/core/sparkplug-client/package-lock.json
@@ -1,24 +1,24 @@
 {
   "name": "sparkplug-client",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "sparkplug-client",
-      "version": "3.2.2",
+      "version": "3.2.3",
       "license": "EPL-2.0",
       "dependencies": {
         "debug": "^4.3.4",
         "mqtt": "^4.2.8",
         "pako": "^2.0.4",
-        "sparkplug-payload": "^1.0.1"
+        "sparkplug-payload": "^1.0.2"
       },
       "devDependencies": {
         "@types/debug": "^4.1.7",
         "@types/node": "^16.11.7",
         "@types/pako": "^2.0.0",
-        "protobufjs": "^6.11.2",
+        "protobufjs": "^6.11.3",
         "typescript": "^4.6.3"
       }
     },
@@ -436,9 +436,9 @@
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
     "node_modules/protobufjs": {
-      "version": "6.11.2",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.2.tgz",
-      "integrity": "sha512-4BQJoPooKJl2G9j3XftkIXjoC9C0Av2NOrWmbLWT1vH32GcSUHjM0Arra6UfTsVyfMAuFzaLucXn1sadxJydAw==",
+      "version": "6.11.3",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.3.tgz",
+      "integrity": "sha512-xL96WDdCZYdU7Slin569tFX712BxsxslWwAfAhCYjQKGTq7dAU91Lomy6nLLhh/dyGhk/YH4TwTSRxTzhuHyZg==",
       "hasInstallScript": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
@@ -517,11 +517,13 @@
       ]
     },
     "node_modules/sparkplug-payload": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/sparkplug-payload/-/sparkplug-payload-1.0.1.tgz",
-      "integrity": "sha512-N4i++SFY7ECH7NB2bi1zmL9uPRKXF5cXQRxudUqZi9sribVZB7TZWvMIcTTakqqs1WkryYgpuV34CwEYm7I0Cg==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/sparkplug-payload/-/sparkplug-payload-1.0.2.tgz",
+      "integrity": "sha512-ezPDzx4EEABwjvdmCND70gUyy179m/EkE6KUK7A5A5xMUMxeZVkXIkqCAeHoWoQ6YErs1Z7ekibapPzw0B2/5w==",
       "dependencies": {
-        "protobufjs": "^6.8.0"
+        "@types/long": "^4.0.0",
+        "long": "^4.0.0",
+        "protobufjs": "^6.11.3"
       }
     },
     "node_modules/split2": {
@@ -943,9 +945,9 @@
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
     "protobufjs": {
-      "version": "6.11.2",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.2.tgz",
-      "integrity": "sha512-4BQJoPooKJl2G9j3XftkIXjoC9C0Av2NOrWmbLWT1vH32GcSUHjM0Arra6UfTsVyfMAuFzaLucXn1sadxJydAw==",
+      "version": "6.11.3",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.3.tgz",
+      "integrity": "sha512-xL96WDdCZYdU7Slin569tFX712BxsxslWwAfAhCYjQKGTq7dAU91Lomy6nLLhh/dyGhk/YH4TwTSRxTzhuHyZg==",
       "requires": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
@@ -1004,11 +1006,13 @@
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
     },
     "sparkplug-payload": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/sparkplug-payload/-/sparkplug-payload-1.0.1.tgz",
-      "integrity": "sha512-N4i++SFY7ECH7NB2bi1zmL9uPRKXF5cXQRxudUqZi9sribVZB7TZWvMIcTTakqqs1WkryYgpuV34CwEYm7I0Cg==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/sparkplug-payload/-/sparkplug-payload-1.0.2.tgz",
+      "integrity": "sha512-ezPDzx4EEABwjvdmCND70gUyy179m/EkE6KUK7A5A5xMUMxeZVkXIkqCAeHoWoQ6YErs1Z7ekibapPzw0B2/5w==",
       "requires": {
-        "protobufjs": "^6.8.0"
+        "@types/long": "^4.0.0",
+        "long": "^4.0.0",
+        "protobufjs": "^6.11.3"
       }
     },
     "split2": {

--- a/javascript/core/sparkplug-client/package.json
+++ b/javascript/core/sparkplug-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sparkplug-client",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "description": "A client module for MQTT communication using the Sparkplug specification from Cirrus Link Solutions",
   "main": "index.js",
   "scripts": {
@@ -34,7 +34,7 @@
     "debug": "^4.3.4",
     "mqtt": "^4.2.8",
     "pako": "^2.0.4",
-    "sparkplug-payload": "^1.0.1"
+    "sparkplug-payload": "^1.0.2"
   },
   "devDependencies": {
     "@types/debug": "^4.1.7",

--- a/javascript/core/sparkplug-payload/README.md
+++ b/javascript/core/sparkplug-payload/README.md
@@ -50,14 +50,16 @@ var decoded = sparkplug.decodePayload(encoded);
 ## Release History
 
 * 1.0.0 Initial release
+* 1.0.1 Bug fixes
+* 1.0.2 Bug fixes, added typescript
 
 ## License
 
-Copyright (c) 2017 Cirrus Link Solutions
+Copyright (c) 2017-2023 Cirrus Link Solutions and others
 
 All rights reserved. This program and the accompanying materials
 are made available under the terms of the Eclipse Public License v1.0
 which accompanies this distribution, and is available at
 http://www.eclipse.org/legal/epl-v10.html
 
-Contributors: Cirrus Link Solutions
+Contributors: Cirrus Link Solutions and others

--- a/javascript/core/sparkplug-payload/package-lock.json
+++ b/javascript/core/sparkplug-payload/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "sparkplug-payload",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@protobufjs/aspromise": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
-      "integrity": "sha1-m4sMxmPWaafY9vXQiToU00jzD78="
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="
     },
     "@protobufjs/base64": {
       "version": "1.1.2",
@@ -22,12 +22,12 @@
     "@protobufjs/eventemitter": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-      "integrity": "sha1-NVy8mLr61ZePntCV85diHx0Ga3A="
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q=="
     },
     "@protobufjs/fetch": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
-      "integrity": "sha1-upn7WYYUr2VwDBYZ/wbUVLDYTEU=",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
       "requires": {
         "@protobufjs/aspromise": "^1.1.1",
         "@protobufjs/inquire": "^1.1.0"
@@ -36,27 +36,27 @@
     "@protobufjs/float": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
-      "integrity": "sha1-Xp4avctz/Ap8uLKR33jIy9l7h9E="
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="
     },
     "@protobufjs/inquire": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
-      "integrity": "sha1-/yAOPnzyQp4tyvwRQIKOjMY48Ik="
+      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q=="
     },
     "@protobufjs/path": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
-      "integrity": "sha1-bMKyDFya1q0NzP0hynZz2Nf79o0="
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA=="
     },
     "@protobufjs/pool": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
-      "integrity": "sha1-Cf0V8tbTq/qbZbw2ZQbWrXhG/1Q="
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="
     },
     "@protobufjs/utf8": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
-      "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
+      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
     },
     "@types/long": {
       "version": "4.0.1",
@@ -74,9 +74,9 @@
       "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
     },
     "protobufjs": {
-      "version": "6.11.2",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.2.tgz",
-      "integrity": "sha512-4BQJoPooKJl2G9j3XftkIXjoC9C0Av2NOrWmbLWT1vH32GcSUHjM0Arra6UfTsVyfMAuFzaLucXn1sadxJydAw==",
+      "version": "6.11.3",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.3.tgz",
+      "integrity": "sha512-xL96WDdCZYdU7Slin569tFX712BxsxslWwAfAhCYjQKGTq7dAU91Lomy6nLLhh/dyGhk/YH4TwTSRxTzhuHyZg==",
       "requires": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",

--- a/javascript/core/sparkplug-payload/package.json
+++ b/javascript/core/sparkplug-payload/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sparkplug-payload",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "A library for encoding and decoding Sparkplug payloads",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Updated versions of the following javascript libraries for release
- sparkplug-payload v1.0.2
- sparkplug-client v3.2.3