### PR TITLE
C: handling of the bytes array type in add_simple_metric

### DIFF
--- a/c/core/src/tahu.c
+++ b/c/core/src/tahu.c
@@ -223,6 +223,9 @@ int set_metric_value(org_eclipse_tahu_protobuf_Payload_Metric *metric, uint32_t 
         memcpy(&metric->value.template_value, value, sizeof(metric->value.template_value));
         break;
     case METRIC_DATA_TYPE_BYTES:
+        metric->which_value = org_eclipse_tahu_protobuf_Payload_Metric_bytes_value_tag;
+        metric->value.bytes_value = (pb_bytes_array_t *)value;
+        break;
     case METRIC_DATA_TYPE_FILE:
     case METRIC_DATA_TYPE_UNKNOWN:
     default:


### PR DESCRIPTION
The supplied value is considered to be a pointer to a dynamically allocated pb_bytes_array_t struct.
That pointer is copied into the bytes_value attribute of the metric value.

I tested that this is enough to get protobuf to successfully encode the bytes into the payload, and that the pointer is freed automatically by the free_payload function.