### PR TITLE
Upticked versions of js libraries sparkplug-payload to 1.0.3, sparkplug-client to 3.2.4

### DIFF
--- a/javascript/core/sparkplug-client/README.md
+++ b/javascript/core/sparkplug-client/README.md
@@ -433,6 +433,7 @@ client.on('close', function () {
 * 3.2.1 Updated License and repo links, cleaned up logging.
 * 3.2.2 Bug Fixes
 * 3.2.3 Bug Fixes, added typescript
+* 3.2.4 Updated sparkplug-payload dependency version.
 
 ## License
 

--- a/javascript/core/sparkplug-client/package-lock.json
+++ b/javascript/core/sparkplug-client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sparkplug-client",
-  "version": "3.2.3",
+  "version": "3.2.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "sparkplug-client",
-      "version": "3.2.3",
+      "version": "3.2.4",
       "license": "EPL-2.0",
       "dependencies": {
         "debug": "^4.3.4",

--- a/javascript/core/sparkplug-client/package.json
+++ b/javascript/core/sparkplug-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sparkplug-client",
-  "version": "3.2.3",
+  "version": "3.2.4",
   "description": "A client module for MQTT communication using the Sparkplug specification from Cirrus Link Solutions",
   "main": "index.js",
   "scripts": {
@@ -34,7 +34,7 @@
     "debug": "^4.3.4",
     "mqtt": "^4.2.8",
     "pako": "^2.0.4",
-    "sparkplug-payload": "^1.0.2"
+    "sparkplug-payload": "^1.0.3"
   },
   "devDependencies": {
     "@types/debug": "^4.1.7",

--- a/javascript/core/sparkplug-payload/README.md
+++ b/javascript/core/sparkplug-payload/README.md
@@ -52,6 +52,7 @@ var decoded = sparkplug.decodePayload(encoded);
 * 1.0.0 Initial release
 * 1.0.1 Bug fixes
 * 1.0.2 Bug fixes, added typescript
+* 1.0.3 Bug fixes
 
 ## License
 

--- a/javascript/core/sparkplug-payload/package-lock.json
+++ b/javascript/core/sparkplug-payload/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sparkplug-payload",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/javascript/core/sparkplug-payload/package.json
+++ b/javascript/core/sparkplug-payload/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sparkplug-payload",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "A library for encoding and decoding Sparkplug payloads",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Published the latest fix 5f73c6ae66e6d30ddc0cce109bad15a00d64e6ea to the Javascript sparkplug libraries and upticked their versions.