### PR TITLE
Fix need to change code to disable DEBUG_PRINT

### DIFF
--- a/c/core/include/tahu.h
+++ b/c/core/include/tahu.h
@@ -29,9 +29,11 @@ extern "C" {
 #endif
 
 // Enable/disable debug messages
+#if !defined(SPARKPLUG_DEBUG)
 #define SPARKPLUG_DEBUG 1
+#endif
 
-#ifdef SPARKPLUG_DEBUG
+#if SPARKPLUG_DEBUG
 #define DEBUG_PRINT(...) printf(__VA_ARGS__)
 #else
 #define DEBUG_PRINT(...) do {} while (0)


### PR DESCRIPTION
This is a fix to issue #323 .

With this fix, the current behaviour does not change.
If SPARKPLUG_DEBUG is not defined anywhere, it's defined in the code and enabled, as the original intent was.

However, if it is defined via compile flags as 0 (**-DSPARKPLUG_DEBUG=0**) , it disables the debug print statements.

It still allows the define to be easily changed in the code from 1 to 0 if necessary.