### PR TITLE
add array support to javascript and correct Python packing functions

### DIFF
--- a/javascript/core/sparkplug-payload/lib/sparkplugbpayload.ts
+++ b/javascript/core/sparkplug-payload/lib/sparkplugbpayload.ts
@@ -358,16 +358,12 @@ function encodeType(typeString: string): number {
             return 23;
         case "INT32ARRAY":
             return 24;
-        case "INT64ARRAY":
-            return 25;
         case "UINT8ARRAY":
             return 26;
         case "UINT16ARRAY":
             return 27;
         case "UINT32ARRAY":
             return 28;
-        case "UINT64ARRAY":
-            return 29;
         case "FLOATARRAY":
             return 30;
         case "DOUBLEARRAY":
@@ -433,16 +429,12 @@ function decodeType (typeInt: number | null | undefined): TypeStr {
             return "Int16Array";
         case 24:
             return "Int32Array";
-        case 25:
-            return "Int64Array";
         case 26:
             return "UInt8Array";
         case 27:
             return "UInt16Array";
         case 28:
             return "UInt32Array";
-        case 29:
-            return "UInt64Array";
         case 30:
             return "FloatArray";
         case 31:

--- a/javascript/core/sparkplug-payload/lib/sparkplugbpayload.ts
+++ b/javascript/core/sparkplug-payload/lib/sparkplugbpayload.ts
@@ -62,10 +62,22 @@ export type TypeStr = "Int8"
     | "File"
     | "Template"
     | "PropertySet"
-    | "PropertySetList";
+    | "PropertySetList"
+    | "Int8Array"
+    | "Int16Array"
+    | "Int32Array"
+    | "Int64Array"
+    | "UInt8Array"
+    | "UInt16Array"
+    | "UInt32Array"
+    | "UInt64Array"
+    | "FloatArray"
+    | "DoubleArray"
+    | "BooleanArray"
+    | "StringArray";
 
 export interface UMetric extends IMetric {
-    value: null | number | Long.Long | boolean | string | Uint8Array | UDataSet | UTemplate;
+    value: null | number | Long.Long | boolean | string | Uint8Array | UDataSet | UTemplate | boolean[] | string[] | number[];
     type: TypeStr;
     properties?: Record<string, UPropertyValue>
 }
@@ -144,6 +156,36 @@ function setValue (type: number, value: UserValue, object: IMetric | IPropertyVa
         case 21:
             (object as IPropertyValue).propertysetsValue = encodePropertySetList(value as UPropertySetList);
             break;
+        case 22:
+            (object as IMetric).bytesValue = encodeInt8Array(value as Array<number>);
+            break;
+        case 23:
+            (object as IMetric).bytesValue = encodeInt16Array(value as Array<number>);
+            break;
+        case 24:
+            (object as IMetric).bytesValue = encodeInt32Array(value as Array<number>);
+            break;
+        case 26:
+            (object as IMetric).bytesValue = encodeUInt8Array(value as Array<number>);
+            break;
+        case 27:
+            (object as IMetric).bytesValue = encodeUInt16Array(value as Array<number>);
+            break;
+        case 28:
+            (object as IMetric).bytesValue = encodeUInt32Array(value as Array<number>);
+            break;
+        case 30:
+            (object as IMetric).bytesValue = encodeFloatArray(value as Array<number>);
+            break;
+        case 31:
+            (object as IMetric).bytesValue = encodeDoubleArray(value as Array<number>);
+            break;
+        case 32:
+            (object as IMetric).bytesValue = encodeBooleanArray(value as Array<boolean>);
+            break;
+        case 33:
+            (object as IMetric).bytesValue = encodeStringArray(value as Array<string>);
+            break;
     } 
 }
 
@@ -194,6 +236,26 @@ function getValue<T extends UserValue> (type: number | null | undefined, object:
             return decodePropertySet((object as IPropertyValue).propertysetValue!) as T;
         case 21:
             return decodePropertySetList((object as IPropertyValue).propertysetsValue!) as T;
+        case 22:
+            return decodeInt8Array((object as IMetric).bytesValue!) as T;
+        case 23:
+            return decodeInt16Array((object as IMetric).bytesValue!) as T;
+        case 24:
+            return decodeInt32Array((object as IMetric).bytesValue!) as T;
+        case 26:
+            return decodeUInt8Array((object as IMetric).bytesValue!) as T;
+        case 27:
+            return decodeUInt16Array((object as IMetric).bytesValue!) as T;
+        case 28:
+            return decodeUInt32Array((object as IMetric).bytesValue!) as T;
+        case 30:
+            return decodeFloatArray((object as IMetric).bytesValue!) as T;
+        case 31:
+            return decodeDoubleArray((object as IMetric).bytesValue!) as T;
+        case 32:
+            return decodeBooleanArray((object as IMetric).bytesValue!) as T;
+        case 33:
+            return decodeStringArray((object as IMetric).bytesValue!) as T;
         default:
             return null;
     } 
@@ -244,7 +306,7 @@ function getTemplateParamValue (type: number | null | undefined, object: IParame
 }
 
 /** transforms a user friendly type and converts it to its corresponding type code */
-function encodeType (typeString: string): number {
+function encodeType(typeString: string): number {
     switch (typeString.toUpperCase()) {
         case "INT8":
             return 1;
@@ -290,6 +352,30 @@ function encodeType (typeString: string): number {
             return 20;
         case "PROPERTYSETLIST":
             return 21;
+        case "INT8ARRAY":
+            return 22;
+        case "INT16ARRAY":
+            return 23;
+        case "INT32ARRAY":
+            return 24;
+        case "INT64ARRAY":
+            return 25;
+        case "UINT8ARRAY":
+            return 26;
+        case "UINT16ARRAY":
+            return 27;
+        case "UINT32ARRAY":
+            return 28;
+        case "UINT64ARRAY":
+            return 29;
+        case "FLOATARRAY":
+            return 30;
+        case "DOUBLEARRAY":
+            return 31;
+        case "BOOLEANARRAY":
+            return 32;
+        case "STRINGARRAY":
+            return 33;
         default:
             return 0;
     }
@@ -305,7 +391,7 @@ function decodeType (typeInt: number | null | undefined): TypeStr {
             return "Int16";
         case 3:
             return "Int32";
-        case 4: 
+        case 4:
             return "Int64";
         case 5:
             return "UInt8";
@@ -341,6 +427,30 @@ function decodeType (typeInt: number | null | undefined): TypeStr {
             return "PropertySet";
         case 21:
             return "PropertySetList";
+        case 22:
+            return "Int8Array";
+        case 23:
+            return "Int16Array";
+        case 24:
+            return "Int32Array";
+        case 25:
+            return "Int64Array";
+        case 26:
+            return "UInt8Array";
+        case 27:
+            return "UInt16Array";
+        case 28:
+            return "UInt32Array";
+        case 29:
+            return "UInt64Array";
+        case 30:
+            return "FloatArray";
+        case 31:
+            return "DoubleArray";
+        case 32:
+            return "BooleanArray";
+        case 33:
+            return "StringArray";
     }
 }
 
@@ -703,6 +813,233 @@ function decodeTemplate (protoTemplate: ITemplate): UTemplate {
     }
 
     return template;
+}
+
+function encodeStringArray(array: Array<string>) {
+    return Buffer.from(array.join("\0") + '\0', 'utf8');
+}
+  
+function decodeStringArray(packedBytes: Uint8Array | null) {
+    if (packedBytes === null) {
+        return null;
+    }
+    return (Buffer.from(packedBytes).toString('utf8')).replace(/\0$/, '').split('\x00');
+}
+
+function encodeInt8Array(array: any[]) {
+    return packValues(array, 'b');
+}
+
+function decodeInt8Array(array: Uint8Array | null) {
+    if (array === null) {
+        return null;
+    }
+    return unpackValues(array, 'b');
+}
+
+function encodeUInt8Array(array: any[]) {
+    return packValues(array, 'B');
+}
+
+function decodeUInt8Array(array: Uint8Array | null) {
+    if (array === null) {
+        return null;
+    }
+    return unpackValues(array, 'B');
+}
+
+function encodeInt16Array(array: any[]) {
+    return packValues(array, 'h');
+}
+
+function decodeInt16Array(array: Uint8Array | null) {
+    if (array === null) {
+        return null;
+    }
+    return unpackValues(array, 'h');
+}
+
+function encodeUInt16Array(array: any[]) {
+    return packValues(array, 'H');
+}
+
+function decodeUInt16Array(array: Uint8Array | null) {
+    if (array === null) {
+        return null;
+    }
+    return unpackValues(array, 'H');
+}
+
+function encodeInt32Array(array: any[]) {
+    return packValues(array, 'i');
+}
+
+function decodeInt32Array(array: Uint8Array | null) {
+    if (array === null) {
+        return null;
+    }
+    return unpackValues(array, 'i');
+}
+
+function encodeUInt32Array(array: any[]) {
+    return packValues(array, 'I');
+}
+
+function decodeUInt32Array(array: Uint8Array | null) {
+    if (array === null) {
+        return null;
+    }
+    return unpackValues(array, 'I');
+}
+
+function encodeFloatArray(array: any[]) {
+    return packValues(array, 'f');
+}
+
+function decodeFloatArray(array: Uint8Array | null) {
+    if (array === null) {
+        return null;
+    }
+    return unpackValues(array, 'f');
+}
+
+function encodeDoubleArray(array: any[]) {
+    return packValues(array, 'd');
+}
+
+function decodeDoubleArray(array: Uint8Array | null) {
+    if (array === null) {
+        return null;
+    }
+    return unpackValues(array, 'd');
+}
+  
+function unpackValues(packed_bytes: Uint8Array, format_specifier: string): number[] {
+    const data_view = new DataView(packed_bytes.buffer, packed_bytes.byteOffset, packed_bytes.byteLength);
+    const decodeFunc = {
+        'b': data_view.getInt8.bind(data_view),
+        'B': data_view.getUint8.bind(data_view),
+        'h': data_view.getInt16.bind(data_view, 0, true),
+        'H': data_view.getUint16.bind(data_view, 0, true),
+        'i': data_view.getInt32.bind(data_view, 0, true),
+        'I': data_view.getUint32.bind(data_view, 0, true),
+        'f': data_view.getFloat32.bind(data_view, 0, true),
+        'd': data_view.getFloat64.bind(data_view, 0, true),
+    }[format_specifier];
+    if (!decodeFunc) {
+        throw new Error(`Unsupported format specifier: ${format_specifier}`);
+    }
+    const values = [];
+    const typeSize = getTypeSize(format_specifier);
+    for (let i = 0; i < packed_bytes.length / typeSize; i++) {
+        values.push(decodeFunc(i * typeSize));
+    }
+    return values;
+}
+
+function packValues(values: any[], format_specifier: string): Uint8Array {
+    const dataView = new DataView(new ArrayBuffer(values.length * getTypeSize(format_specifier)));
+    let byteOffset = 0;
+    for (let i = 0; i < values.length; i++) {
+        const value = values[i];
+        switch (format_specifier) {
+            case 'b':
+                dataView.setInt8(byteOffset, value);
+                byteOffset += 1;
+                break;
+            case 'B':
+                dataView.setUint8(byteOffset, value);
+                byteOffset += 1;
+                break;
+            case 'h':
+                dataView.setInt16(byteOffset, value, true);
+                byteOffset += 2;
+                break;
+            case 'H':
+                dataView.setUint16(byteOffset, value, true);
+                byteOffset += 2;
+                break;
+            case 'i':
+                dataView.setInt32(byteOffset, value, true);
+                byteOffset += 4;
+                break;
+            case 'I':
+                dataView.setUint32(byteOffset, value, true);
+                byteOffset += 4;
+                break;
+            case 'f':
+                dataView.setFloat32(byteOffset, value, true);
+                byteOffset += 4;
+                break;
+            case 'd':
+                dataView.setFloat64(byteOffset, value, true);
+                byteOffset += 8;
+                break;
+            default:
+                throw new Error(`Unsupported format specifier: ${format_specifier}`);
+        }
+    }
+    return new Uint8Array(dataView.buffer);
+}
+
+function getTypeSize(format_specifier: string): number {
+    const sizeMap: {[key: string]: number} = {
+        'b': 1,
+        'B': 1,
+        'h': 2,
+        'H': 2,
+        'i': 4,
+        'I': 4,
+        'f': 4,
+        'd': 8,
+    };
+    const size = sizeMap[format_specifier];
+    if (!size) {
+        throw new Error(`Unsupported format specifier: ${format_specifier}`);
+    }
+    return size;
+}
+
+function encodeBooleanArray(booleanArray: boolean[]): Uint8Array {
+    // calculate the number of packed bytes required
+    const packedBytesCount = Math.ceil(booleanArray.length / 8);
+
+    // convert the boolean array into a packed byte array
+    const packedBytes = new Uint8Array(packedBytesCount);
+
+    for (let i = 0; i < booleanArray.length; i++) {
+        const value = booleanArray[i];
+        const byteIndex = Math.floor(i / 8);
+        const bitIndex = i % 8;
+        packedBytes[byteIndex] |= (value ? 1 : 0) << bitIndex;
+    }
+
+    // return the packed bytes preceded by a 4-byte integer representing the number of boolean values
+    const lengthBytes = new Uint8Array(new Uint32Array([booleanArray.length]).buffer);
+    const result = new Uint8Array(lengthBytes.length + packedBytes.length);
+    result.set(lengthBytes);
+    result.set(packedBytes, lengthBytes.length);
+
+    return result;
+}
+
+function decodeBooleanArray(packedBytes: Uint8Array): boolean[] {
+    // extract the length of the boolean array from the first 4 bytes of the packed bytes
+    const lengthBytes = packedBytes.slice(0, 4);
+    const length = new Uint32Array(lengthBytes.buffer)[0];
+
+    // create a boolean array of the appropriate length
+    const booleanArray = new Array<boolean>(length);
+
+    // iterate over each bit in the packed bytes and set the corresponding boolean value in the boolean array
+    for (let i = 0; i < length; i++) {
+        const byteIndex = Math.floor(i / 8);
+        const bitIndex = i % 8;
+        const mask = 1 << bitIndex;
+        booleanArray[i] = (packedBytes[byteIndex + 4] & mask) !== 0;
+    }
+
+    return booleanArray;
 }
 
 function encodeMetric (metric: UMetric): ProtoRoot.org.eclipse.tahu.protobuf.Payload.Metric {

--- a/javascript/core/sparkplug-payload/package-lock.json
+++ b/javascript/core/sparkplug-payload/package-lock.json
@@ -1,83 +1,98 @@
 {
   "name": "sparkplug-payload",
   "version": "1.0.3",
-  "lockfileVersion": 1,
+  "lockfileVersion": 3,
   "requires": true,
-  "dependencies": {
-    "@protobufjs/aspromise": {
+  "packages": {
+    "": {
+      "name": "sparkplug-payload",
+      "version": "1.0.3",
+      "license": "EPL-2.0",
+      "dependencies": {
+        "@types/long": "^4.0.0",
+        "long": "^4.0.0",
+        "protobufjs": "^6.11.3"
+      },
+      "devDependencies": {
+        "@types/node": "^16.18.68",
+        "typescript": "^4.6.3"
+      }
+    },
+    "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
       "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="
     },
-    "@protobufjs/base64": {
+    "node_modules/@protobufjs/base64": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
       "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="
     },
-    "@protobufjs/codegen": {
+    "node_modules/@protobufjs/codegen": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
       "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="
     },
-    "@protobufjs/eventemitter": {
+    "node_modules/@protobufjs/eventemitter": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
       "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q=="
     },
-    "@protobufjs/fetch": {
+    "node_modules/@protobufjs/fetch": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
       "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
-      "requires": {
+      "dependencies": {
         "@protobufjs/aspromise": "^1.1.1",
         "@protobufjs/inquire": "^1.1.0"
       }
     },
-    "@protobufjs/float": {
+    "node_modules/@protobufjs/float": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
       "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="
     },
-    "@protobufjs/inquire": {
+    "node_modules/@protobufjs/inquire": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
       "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q=="
     },
-    "@protobufjs/path": {
+    "node_modules/@protobufjs/path": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
       "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA=="
     },
-    "@protobufjs/pool": {
+    "node_modules/@protobufjs/pool": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
       "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="
     },
-    "@protobufjs/utf8": {
+    "node_modules/@protobufjs/utf8": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
     },
-    "@types/long": {
+    "node_modules/@types/long": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.1.tgz",
       "integrity": "sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w=="
     },
-    "@types/node": {
-      "version": "16.11.29",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.29.tgz",
-      "integrity": "sha512-9dDdonLyPJQJ/kdOlDxAah+bTI+u2ccF3k62FErhquDuggoCX6piWez7j7o6yNE+rP2IRcZVQ6Tw4N0P38+rWA=="
+    "node_modules/@types/node": {
+      "version": "16.18.68",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.68.tgz",
+      "integrity": "sha512-sG3hPIQwJLoewrN7cr0dwEy+yF5nD4D/4FxtQpFciRD/xwUzgD+G05uxZHv5mhfXo4F9Jkp13jjn0CC2q325sg=="
     },
-    "long": {
+    "node_modules/long": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
       "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
     },
-    "protobufjs": {
+    "node_modules/protobufjs": {
       "version": "6.11.3",
       "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.3.tgz",
       "integrity": "sha512-xL96WDdCZYdU7Slin569tFX712BxsxslWwAfAhCYjQKGTq7dAU91Lomy6nLLhh/dyGhk/YH4TwTSRxTzhuHyZg==",
-      "requires": {
+      "hasInstallScript": true,
+      "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
         "@protobufjs/codegen": "^2.0.4",
@@ -91,13 +106,24 @@
         "@types/long": "^4.0.1",
         "@types/node": ">=13.7.0",
         "long": "^4.0.0"
+      },
+      "bin": {
+        "pbjs": "bin/pbjs",
+        "pbts": "bin/pbts"
       }
     },
-    "typescript": {
+    "node_modules/typescript": {
       "version": "4.6.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.3.tgz",
       "integrity": "sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==",
-      "dev": true
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
     }
   }
 }

--- a/javascript/core/sparkplug-payload/tsconfig.json
+++ b/javascript/core/sparkplug-payload/tsconfig.json
@@ -12,7 +12,7 @@
 
     /* Language and Environment */
     "target": "es2016",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
-    // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
+    "lib": ["ES2021"],                                   /* Specify a set of bundled library declaration files that describe the target runtime environment. */
     // "jsx": "preserve",                                /* Specify what JSX code is generated. */
     // "experimentalDecorators": true,                   /* Enable experimental support for TC39 stage 2 draft decorators. */
     // "emitDecoratorMetadata": true,                    /* Emit design-type metadata for decorated declarations in source files. */

--- a/python/core/array_packer.py
+++ b/python/core/array_packer.py
@@ -71,15 +71,10 @@ def convert_to_packed_boolean_array(boolean_array):
     return struct.pack("<I", len(boolean_array)) + packed_bytes
 
 def convert_to_packed_string_array(array):
-    # convert strings to bytes and encode to hex
-    hex_string_array = [string.encode().hex() for string in array]
-    # convert hex string to bytes and terminate with null character
-    packed_bytes = [bytes(hex_string, 'utf-8') + b'\x00' for hex_string in hex_string_array]
-    # joining the bytes to form a null terminated byte string
-    return b''.join(packed_bytes)
+    return '\0'.join(array + ['']).encode('utf-8')
 
 def convert_to_packed_datetime_array(array):
-    # convert receievd epoch time to 8-byte (int64) array
+    # convert received epoch time to 8-byte (int64) array
     packed_bytes = convert_to_packed_int64_array(array)
     return packed_bytes
 
@@ -131,13 +126,7 @@ def convert_from_packed_boolean_array(packed_bytes):
     return boolean_array
 
 def convert_from_packed_string_array(packed_bytes):
-    string_array = []
-    # packed bytes are decoded and stripped of null characters
-    decoded_hex_string = packed_bytes.decode('utf-8').split('\x00')
-    for hex_string in decoded_hex_string:
-        # resulting hex string is converted to byte and then to decoded to strings
-        string_array.append(bytes.fromhex(hex_string).decode())
-    return string_array
+    return packed_bytes.decode('utf-8').strip('\0').split('\0')
 
 def convert_from_packed_datetime_array(packed_bytes):
     # unpack the packed bytes the result will be epoch values


### PR DESCRIPTION
Add array support for javascript encoding and decoding (int64 and Uint64 array types are not included).  Correct the Python encode and decode functions for StringArrays. The previous version converting to hex strings then bytes, which is not correct way to pack the string array. 