### PR TITLE
MQTT client option

### DIFF
--- a/javascript/core/sparkplug-client/index.ts
+++ b/javascript/core/sparkplug-client/index.ts
@@ -475,10 +475,18 @@ class SparkplugClient extends events.EventEmitter {
                 return;
             }
 
-            let payload = this.maybeDecompressPayload(this.decodePayload(message)),
-                timestamp = payload.timestamp,
-                splitTopic,
-                metrics;
+            let payload: UPayload;
+            let timestamp: number | Long.Long | null | undefined;
+            let splitTopic: string[];
+
+            // catch any errors thrown by the decodePayload function
+            try {
+                payload = this.maybeDecompressPayload(this.decodePayload(message));
+                timestamp = payload.timestamp;
+            } catch (err) {
+                this.emit("error", err as Error);
+                return;
+            }
 
             this.messageAlert("arrived", topic, payload);
 

--- a/javascript/core/sparkplug-client/package-lock.json
+++ b/javascript/core/sparkplug-client/package-lock.json
@@ -12,7 +12,7 @@
         "debug": "^4.3.4",
         "mqtt": "^4.2.8",
         "pako": "^2.0.4",
-        "sparkplug-payload": "^1.0.2"
+        "sparkplug-payload": "^1.0.3"
       },
       "devDependencies": {
         "@types/debug": "^4.1.7",
@@ -517,9 +517,9 @@
       ]
     },
     "node_modules/sparkplug-payload": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/sparkplug-payload/-/sparkplug-payload-1.0.2.tgz",
-      "integrity": "sha512-ezPDzx4EEABwjvdmCND70gUyy179m/EkE6KUK7A5A5xMUMxeZVkXIkqCAeHoWoQ6YErs1Z7ekibapPzw0B2/5w==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sparkplug-payload/-/sparkplug-payload-1.0.3.tgz",
+      "integrity": "sha512-JAQSyuHVQQe/LzIlJdcIaD1F1c+rbXoolII3H1whQkhuZ96+G53RoPWqP9zCPZYFjvfSMHnQNIedGIZw/zjHJw==",
       "dependencies": {
         "@types/long": "^4.0.0",
         "long": "^4.0.0",
@@ -1006,9 +1006,9 @@
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
     },
     "sparkplug-payload": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/sparkplug-payload/-/sparkplug-payload-1.0.2.tgz",
-      "integrity": "sha512-ezPDzx4EEABwjvdmCND70gUyy179m/EkE6KUK7A5A5xMUMxeZVkXIkqCAeHoWoQ6YErs1Z7ekibapPzw0B2/5w==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sparkplug-payload/-/sparkplug-payload-1.0.3.tgz",
+      "integrity": "sha512-JAQSyuHVQQe/LzIlJdcIaD1F1c+rbXoolII3H1whQkhuZ96+G53RoPWqP9zCPZYFjvfSMHnQNIedGIZw/zjHJw==",
       "requires": {
         "@types/long": "^4.0.0",
         "long": "^4.0.0",


### PR DESCRIPTION
Modified the type of options passed to `SparkplugClient` so that you can either pass options to create an MQTT client, or you can pass an MQTT client directly.

I have a service that creates sparkplug nodes which all connect to the same broker. The current version of sparkplug-client creates an mqtt client for each sparkplug client, which feels wasteful in this scenario. I wanted to optimize this, and also have a single place to check for MQTT client disconnects.

---------

In this PR, the type of the options are changed to have things like `serverUrl`, `username` be optional, but it's expected that either the options to create an mqtt client are provided, OR an mqtt client is provided directly.

If an mqtt client needs to be created, it is now done in the constructor instead of `init`, and `init` is now mainly responsible for initializing the client.

One behavior change worth noting though, is that the `connect` event will not be useable if an already connected mqtt client is provided, because the event will fire before anything gets a chance to add a listener. This is probably not a problem for existing projects.