### PR TITLE
c/core: Use <inttypes.h> macros to construct printf format specifiers

### DIFF
--- a/c/core/include/tahu.h
+++ b/c/core/include/tahu.h
@@ -37,6 +37,39 @@ extern "C" {
 #define DEBUG_PRINT(...) do {} while (0)
 #endif
 
+// Inttype format specifiers
+#if defined(PB_FIELD_32BIT)
+#define PRI_b_PB_SIZE   PRIb32
+#define PRI_B_PB_SIZE   PRIB32
+#define PRI_d_PB_SIZE   PRId32
+#define PRI_i_PB_SIZE   PRIi32
+#define PRI_o_PB_SIZE   PRIo32
+#define PRI_u_PB_SIZE   PRIu32
+#define PRI_x_PB_SIZE   PRIx32
+#define PRI_X_PB_SIZE   PRIX32
+#define SCN_b_PB_SIZE   SCNb32
+#define SCN_d_PB_SIZE   SCNd32
+#define SCN_i_PB_SIZE   SCNi32
+#define SCN_o_PB_SIZE   SCNo32
+#define SCN_u_PB_SIZE   SCNu32
+#define SCN_x_PB_SIZE   SCNx32
+#else
+#define PRI_b_PB_SIZE   PRIbLEAST16
+#define PRI_B_PB_SIZE   PRIBLEAST16
+#define PRI_d_PB_SIZE   PRIdLEAST16
+#define PRI_i_PB_SIZE   PRIiLEAST16
+#define PRI_o_PB_SIZE   PRIoLEAST16
+#define PRI_u_PB_SIZE   PRIuLEAST16
+#define PRI_x_PB_SIZE   PRIxLEAST16
+#define PRI_X_PB_SIZE   PRIXLEAST16
+#define SCN_b_PB_SIZE   SCNbLEAST16
+#define SCN_d_PB_SIZE   SCNdLEAST16
+#define SCN_i_PB_SIZE   SCNiLEAST16
+#define SCN_o_PB_SIZE   SCNoLEAST16
+#define SCN_u_PB_SIZE   SCNuLEAST16
+#define SCN_x_PB_SIZE   SCNxLEAST16
+#endif
+
 // Constants
 #define DATA_SET_DATA_TYPE_UNKNOWN 0
 #define DATA_SET_DATA_TYPE_INT8 1


### PR DESCRIPTION
Avoid warnings about printf parameter types not matching the format specifiers by using the macros defined by `#include <inttypes.h>` to construct the format specifiers.  Also fix some format specifiers for parameters of type `size_t`.

The types of `pb_size_t` and `pb_ssize_t` depend on whether the `PB_FIELD_32BIT` macro is defined or not in "pb.h", so add macros to "tahu.h" that expand to the correct printf and scanf format specifiers for `pb_size_t` and `pb_ssize_t`.  For example, define `PRI_u_PB_SIZE` to expand to `PRIu32` if `PB_FIELD_32BIT` is defined, or to `PRIuLEAST16` if `PB_FIELD_32BIT` is undefined.  (The underscore after `PRI` avoids clashes with identifiers reserved for future use by `<inttypes.h>`.)