### PR TITLE
c/core: Fix possible clean-up problem in init_dataset()

### DIFF
--- a/c/core/src/tahu.c
+++ b/c/core/src/tahu.c
@@ -386,6 +386,10 @@ int init_dataset(org_eclipse_tahu_protobuf_Payload_DataSet *dataset,
     for (int i = 0; i < num_of_columns; i++) {
         dataset->columns[i] = strdup(column_keys[i]);
         if (dataset->columns[i] == NULL) {
+            // Initialize remaining columns[] pointers.
+            while (i++ < num_of_columns) {
+                dataset->columns[i] = NULL;
+            }
             fprintf(stderr, "strdup failed in init_dataset\n");
             return -1;
         }


### PR DESCRIPTION
If there is a memory allocation failure when copying the column keys, the dynamically allocated `dataset->columns[]` array is left in an inconsistent state because remaining elements are left in an uninitialized state.  If the dataset is later cleaned up with `pb_release()`, it will try and free memory referenced by these uninitialized `dataset->columns[]` elements leading to undefined behavior.  Fix it by setting the remaining `dataset->columns[]` elements to `NULL` on failure.

Fixes #357.