### PR TITLE
c/core: Fix memory leak and stale pointers in add_property_to_set()

### DIFF
--- a/c/core/src/tahu.c
+++ b/c/core/src/tahu.c
@@ -127,13 +127,17 @@ int add_property_to_set(org_eclipse_tahu_protobuf_Payload_PropertySet *propertys
     void *key_allocation_result = realloc(propertyset->keys, key_allocation_size);
     void *value_allocation_result = realloc(propertyset->values, value_allocation_size);
     //DEBUG_PRINT("key=%p value=%p\n", key_allocation_result, value_allocation_result);
+    if (key_allocation_result != NULL) {
+        propertyset->keys = key_allocation_result;
+    }
+    if (value_allocation_result != NULL) {
+        propertyset->values = value_allocation_result;
+    }
     if ((key_allocation_result == NULL) || (value_allocation_result == NULL)) {
         fprintf(stderr, "realloc failed in add_metric_to_payload\n");
         return -1;
     }
-    propertyset->keys = key_allocation_result;
     propertyset->keys_count = new_count;
-    propertyset->values = value_allocation_result;
     propertyset->values_count = new_count;
     propertyset->keys[old_count] = strdup(key);
     if (propertyset->keys[old_count] == NULL) {


### PR DESCRIPTION
`realloc()` is called twice to reallocate two blocks of memory to a larger size before checking the result of either.  The function returns an error if either reallocation failed, but not before updating the original pointer for the one that succeeded (if any).  This would result in undefined behavior when the property set is cleaned up by `pb_release()`.  Fix it by updating the original pointers for each successful reallocation.

Fixes #360.