### PR TITLE
c/core: Allow 0 rows or 0 columns in init_dataset()

### DIFF
--- a/c/core/src/tahu.c
+++ b/c/core/src/tahu.c
@@ -382,11 +382,15 @@ int init_dataset(org_eclipse_tahu_protobuf_Payload_DataSet *dataset,
     dataset->has_num_of_columns = true;
     dataset->num_of_columns = num_of_columns;
     dataset->columns_count = num_of_columns;
-    const size_t key_size = num_of_columns * sizeof(char *);
-    dataset->columns = malloc(key_size);
-    if (dataset->columns == NULL) {
-        fprintf(stderr, "malloc(%zu) failure in init_dataset\n", key_size);
-        return -1;
+    if (num_of_columns == 0) {
+        dataset->columns = NULL;
+    } else {
+        const size_t key_size = num_of_columns * sizeof(char *);
+        dataset->columns = malloc(key_size);
+        if (dataset->columns == NULL) {
+            fprintf(stderr, "malloc(%zu) failure in init_dataset\n", key_size);
+            return -1;
+        }
     }
     for (int i = 0; i < num_of_columns; i++) {
         dataset->columns[i] = strdup(column_keys[i]);
@@ -400,21 +404,29 @@ int init_dataset(org_eclipse_tahu_protobuf_Payload_DataSet *dataset,
         }
     }
     dataset->types_count = num_of_columns;
-    const size_t datatypes_size = num_of_columns * sizeof(uint32_t);
-    dataset->types = malloc(datatypes_size);
-    if (dataset->types == NULL) {
-        fprintf(stderr, "malloc(%zu) failure in init_dataset\n", datatypes_size);
-        return -1;
+    if (num_of_columns == 0) {
+        dataset->types = NULL;
+    } else {
+        const size_t datatypes_size = num_of_columns * sizeof(uint32_t);
+        dataset->types = malloc(datatypes_size);
+        if (dataset->types == NULL) {
+            fprintf(stderr, "malloc(%zu) failure in init_dataset\n", datatypes_size);
+            return -1;
+        }
+        memcpy(dataset->types, datatypes, datatypes_size);
     }
-    memcpy(dataset->types, datatypes, datatypes_size);
     dataset->rows_count = num_of_rows;
-    const size_t row_data_size = num_of_rows * sizeof(org_eclipse_tahu_protobuf_Payload_DataSet_Row);
-    dataset->rows = malloc(row_data_size);
-    if (dataset->rows == NULL) {
-        fprintf(stderr, "malloc(%zu) failure in init_dataset\n", row_data_size);
-        return -1;
+    if (num_of_rows == 0) {
+        dataset->rows = NULL;
+    } else {
+        const size_t row_data_size = num_of_rows * sizeof(org_eclipse_tahu_protobuf_Payload_DataSet_Row);
+        dataset->rows = malloc(row_data_size);
+        if (dataset->rows == NULL) {
+            fprintf(stderr, "malloc(%zu) failure in init_dataset\n", row_data_size);
+            return -1;
+        }
+        memcpy(dataset->rows, row_data, row_data_size);
     }
-    memcpy(dataset->rows, row_data, row_data_size);
     return 0;
 }
 


### PR DESCRIPTION
If the `num_of_columns` or `num_of_rows` parameter value is 0, some of the memory allocations will have size 0, so the calls to `malloc()` may return `NULL`, causing `init_dataset()` to return an error.  Change the function to only allocate `dataset->columns` and `dataset->types` if `num_of_columns` is not 0, and to only allocate `dataset->rows` if `num_of_rows` is not 0, setting the pointers to `NULL` without returning an error when not allocated.