### PR TITLE
Add isValidTopic() for lightweight Sparkplug topic validation

### DIFF
--- a/java/lib/core/src/main/java/org/eclipse/tahu/message/model/Topic.java
+++ b/java/lib/core/src/main/java/org/eclipse/tahu/message/model/Topic.java
@@ -236,6 +236,41 @@ public class Topic {
 	}
 
 	/**
+	 * Checks whether the given MQTT topic string is a valid Sparkplug topic.
+	 * Unlike {@link #parseTopic(String)}, this method does not throw exceptions.
+	 *
+	 * @param topicString the MQTT topic string to check
+	 * @return {@code true} if the topic string is a valid Sparkplug topic, {@code false} otherwise
+	 */
+	public static boolean isValidTopic(String topicString) {
+		try {
+			if (topicString == null || !topicString.startsWith(SparkplugMeta.SPARKPLUG_B_TOPIC_PREFIX) || !topicString.contains("/")) {
+				return false;
+			}
+
+			String[] splitTopic = topicString.split("/");
+			if (splitTopic.length == 3) {
+                return SparkplugMeta.SPARKPLUG_B_TOPIC_PREFIX.equals(splitTopic[0])
+                        && SparkplugMeta.SPARKPLUG_TOPIC_HOST_STATE_TOKEN.equals(splitTopic[1]);
+			} else if (splitTopic.length == 4) {
+				MessageType messageType = MessageType.parseMessageType(splitTopic[2]);
+                return SparkplugMeta.SPARKPLUG_B_TOPIC_PREFIX.equals(splitTopic[0]) && (messageType == MessageType.NBIRTH
+                        || messageType == MessageType.NCMD || messageType == MessageType.NDATA
+                        || messageType == MessageType.NDEATH || messageType == MessageType.NRECORD);
+			} else if (splitTopic.length == 5) {
+				MessageType messageType = MessageType.parseMessageType(splitTopic[2]);
+                return SparkplugMeta.SPARKPLUG_B_TOPIC_PREFIX.equals(splitTopic[0]) && (messageType == MessageType.DBIRTH
+                        || messageType == MessageType.DCMD || messageType == MessageType.DDATA
+                        || messageType == MessageType.DDEATH || messageType == MessageType.DRECORD);
+			} else {
+				return false;
+			}
+		} catch (Exception e) {
+			return false;
+		}
+	}
+
+	/**
 	 * Returns the Sparkplug namespace version.
 	 * 
 	 * @return the namespace

--- a/java/lib/core/src/test/java/org/eclipse/tahu/test/TopicTest.java
+++ b/java/lib/core/src/test/java/org/eclipse/tahu/test/TopicTest.java
@@ -1,0 +1,55 @@
+/********************************************************************************
+ * Copyright (c) 2025 Cirrus Link Solutions and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Cirrus Link Solutions - initial implementation
+ ********************************************************************************/
+
+package org.eclipse.tahu.test;
+
+import junit.framework.TestCase;
+import org.eclipse.tahu.message.model.Topic;
+
+public class TopicTest extends TestCase {
+    public void testValidStateTopic() {
+        assertTrue(Topic.isValidTopic("spBv1.0/STATE/myGroup"));
+    }
+
+    public void testValidEdgeNodeTopic() {
+        assertTrue(Topic.isValidTopic("spBv1.0/myGroup/NBIRTH/myNode"));
+        assertTrue(Topic.isValidTopic("spBv1.0/myGroup/NDATA/myNode"));
+    }
+
+    public void testValidDeviceTopic() {
+        assertTrue(Topic.isValidTopic("spBv1.0/myGroup/DBIRTH/myNode/myDevice"));
+        assertTrue(Topic.isValidTopic("spBv1.0/myGroup/DRECORD/myNode/myDevice"));
+    }
+
+    public void testInvalidNull() {
+        assertFalse(Topic.isValidTopic(null));
+    }
+
+    public void testInvalidEmpty() {
+        assertFalse(Topic.isValidTopic(""));
+    }
+
+    public void testInvalidPrefix() {
+        assertFalse(Topic.isValidTopic("spAv1.0/myGroup/NDATA/myNode"));
+    }
+
+    public void testInvalidMessageType() {
+        assertFalse(Topic.isValidTopic("spBv1.0/myGroup/UNKNOWN/myNode"));
+    }
+
+    public void testInvalidLength() {
+        assertFalse(Topic.isValidTopic("spBv1.0"));
+        assertFalse(Topic.isValidTopic("spBv1.0/group/NDATA"));
+        assertFalse(Topic.isValidTopic("spBv1.0/Group 1/DBIRTH/Edge 1/Device 2/token1/token2"));
+    }
+}


### PR DESCRIPTION
This PR adds a new utility method, `isValidTopic(String)`, which performs the same validation as `parseTopic(String)` but without throwing exceptions. It's intended for use in performance-sensitive contexts where the caller wants to check topic validity before parsing. This addition helps avoid using exception-based control flow when parsing invalid MQTT topics that don’t conform to Sparkplug specification.