### PR TITLE
Fix Issue #323: Allow disabling SPARKPLUG_DEBUG using compile flags

### DIFF
--- a/c/core/include/tahu.h
+++ b/c/core/include/tahu.h
@@ -29,9 +29,11 @@ extern "C" {
 #endif
 
 // Enable/disable debug messages
+#ifndef SPARKPLUG_DEBUG
 #define SPARKPLUG_DEBUG 1
+#endif
 
-#ifdef SPARKPLUG_DEBUG
+#if SPARKPLUG_DEBUG
 #define DEBUG_PRINT(...) printf(__VA_ARGS__)
 #else
 #define DEBUG_PRINT(...) do {} while (0)

--- a/c/core/src/tahu.c
+++ b/c/core/src/tahu.c
@@ -320,7 +320,7 @@ ssize_t decode_payload(org_eclipse_tahu_protobuf_Payload *payload,
         return -1;
     }
 
-#ifdef SPARKPLUG_DEBUG
+#if SPARKPLUG_DEBUG
     // Print the message data
     print_payload(payload);
 #endif


### PR DESCRIPTION
Proposing fix for [Issue #323](https://github.com/eclipse-tahu/tahu/issues/323).

This change allows to disable SPARKPLUG_DEBUG through compile flag. Otherwise if we want to disable the Debug we have to change the source code and this implies in "Modified Work" according to EPL 2.0 license.