### PR TITLE
Changed URL validation to use java.net.URL instead of paho's NetworkModuleService

### DIFF
--- a/java/lib/core/src/main/java/org/eclipse/tahu/mqtt/TahuClient.java
+++ b/java/lib/core/src/main/java/org/eclipse/tahu/mqtt/TahuClient.java
@@ -13,6 +13,7 @@
 
 package org.eclipse.tahu.mqtt;
 
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -34,7 +35,6 @@ import org.eclipse.paho.client.mqttv3.MqttConnectOptions;
 import org.eclipse.paho.client.mqttv3.MqttException;
 import org.eclipse.paho.client.mqttv3.MqttMessage;
 import org.eclipse.paho.client.mqttv3.MqttSecurityException;
-import org.eclipse.paho.client.mqttv3.internal.NetworkModuleService;
 import org.eclipse.tahu.exception.TahuErrorCode;
 import org.eclipse.tahu.exception.TahuException;
 import org.eclipse.tahu.message.model.StatePayload;
@@ -702,7 +702,7 @@ public class TahuClient implements MqttCallbackExtended {
 	 */
 	public void connect() {
 		try {
-			NetworkModuleService.validateURI(mqttServerUrl.getMqttServerUrl());
+			new URL(mqttServerUrl.getMqttServerUrl()).toURI();
 		} catch (Exception e) {
 			logger.error("{}: Invalid MQTT Server URL: {}", getClientId(), mqttServerUrl.getMqttServerUrl());
 			return;


### PR DESCRIPTION
Changed the `TahoClient` to not use `org.eclipse.paho.client.mqttv3.internal.NetworkModuleService` class which is not exported by the `org.eclipse.paho.client.mqttv3` library