### PR TITLE
Modified HostApplicationEventHandler interface to pass along the MQTT server name

### DIFF
--- a/java/compat_impl/host/src/main/java/org/eclipse/tahu/host/SparkplugHostApplication.java
+++ b/java/compat_impl/host/src/main/java/org/eclipse/tahu/host/SparkplugHostApplication.java
@@ -18,7 +18,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.eclipse.tahu.exception.TahuException;
-import org.eclipse.tahu.host.api.HostApplicationEventHandler;
+import org.eclipse.tahu.host.api.MultiHostApplicationEventHandler;
 import org.eclipse.tahu.message.SparkplugBPayloadDecoder;
 import org.eclipse.tahu.message.model.DeviceDescriptor;
 import org.eclipse.tahu.message.model.EdgeNodeDescriptor;
@@ -33,7 +33,7 @@ import org.eclipse.tahu.mqtt.MqttServerUrl;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class SparkplugHostApplication implements HostApplicationEventHandler {
+public class SparkplugHostApplication implements MultiHostApplicationEventHandler {
 
 	private static Logger logger = LoggerFactory.getLogger(SparkplugHostApplication.class.getName());
 
@@ -120,91 +120,91 @@ public class SparkplugHostApplication implements HostApplicationEventHandler {
 	}
 
 	@Override
-	public void onConnect() {
+	public void onConnect(MqttServerName serverName) {
 		logger.info("onConnect...");
 	}
 
 	@Override
-	public void onDisconnect() {
+	public void onDisconnect(MqttServerName serverName) {
 		logger.info("onDisconnect...");
 	}
 
 	@Override
-	public void onNodeBirthArrived(EdgeNodeDescriptor edgeNodeDescriptor, Message message) {
+	public void onNodeBirthArrived(MqttServerName serverName, EdgeNodeDescriptor edgeNodeDescriptor, Message message) {
 		logger.info("onNodeBirthArrived from {}...", edgeNodeDescriptor);
 	}
 
 	@Override
-	public void onNodeBirthComplete(EdgeNodeDescriptor edgeNodeDescriptor) {
+	public void onNodeBirthComplete(MqttServerName serverName, EdgeNodeDescriptor edgeNodeDescriptor) {
 		logger.info("onNodeBirthComplete from {}...", edgeNodeDescriptor);
 	}
 
 	@Override
-	public void onNodeDataArrived(EdgeNodeDescriptor edgeNodeDescriptor, Message message) {
+	public void onNodeDataArrived(MqttServerName serverName, EdgeNodeDescriptor edgeNodeDescriptor, Message message) {
 		logger.info("onNodeDataArrived from {}...", edgeNodeDescriptor);
 	}
 
 	@Override
-	public void onNodeDataComplete(EdgeNodeDescriptor edgeNodeDescriptor) {
+	public void onNodeDataComplete(MqttServerName serverName, EdgeNodeDescriptor edgeNodeDescriptor) {
 		logger.info("onNodeDataComplete from {}...", edgeNodeDescriptor);
 	}
 
 	@Override
-	public void onNodeDeath(EdgeNodeDescriptor edgeNodeDescriptor, Message message) {
+	public void onNodeDeath(MqttServerName serverName, EdgeNodeDescriptor edgeNodeDescriptor, Message message) {
 		logger.info("onNodeDeath from {}...", edgeNodeDescriptor);
 	}
 
 	@Override
-	public void onNodeDeathComplete(EdgeNodeDescriptor edgeNodeDescriptor) {
+	public void onNodeDeathComplete(MqttServerName serverName, EdgeNodeDescriptor edgeNodeDescriptor) {
 		logger.info("onNodeDeathComplete from {}...", edgeNodeDescriptor);
 	}
 
 	@Override
-	public void onDeviceBirthArrived(DeviceDescriptor deviceDescriptor, Message message) {
+	public void onDeviceBirthArrived(MqttServerName serverName, DeviceDescriptor deviceDescriptor, Message message) {
 		logger.info("onDeviceBirthArrived from {}...", deviceDescriptor);
 	}
 
 	@Override
-	public void onDeviceBirthComplete(DeviceDescriptor deviceDescriptor) {
+	public void onDeviceBirthComplete(MqttServerName serverName, DeviceDescriptor deviceDescriptor) {
 		logger.info("onDeviceBirthComplete from {}...", deviceDescriptor);
 	}
 
 	@Override
-	public void onDeviceDataArrived(DeviceDescriptor deviceDescriptor, Message message) {
+	public void onDeviceDataArrived(MqttServerName serverName, DeviceDescriptor deviceDescriptor, Message message) {
 		logger.info("onDeviceDataArrived from {}...", deviceDescriptor);
 	}
 
 	@Override
-	public void onDeviceDataComplete(DeviceDescriptor deviceDescriptor) {
+	public void onDeviceDataComplete(MqttServerName serverName, DeviceDescriptor deviceDescriptor) {
 		logger.info("onDeviceDataComplete from {}...", deviceDescriptor);
 	}
 
 	@Override
-	public void onDeviceDeath(DeviceDescriptor deviceDescriptor, Message message) {
+	public void onDeviceDeath(MqttServerName serverName, DeviceDescriptor deviceDescriptor, Message message) {
 		logger.info("onDeviceDeath from {}...", deviceDescriptor);
 	}
 
 	@Override
-	public void onDeviceDeathComplete(DeviceDescriptor deviceDescriptor) {
+	public void onDeviceDeathComplete(MqttServerName serverName, DeviceDescriptor deviceDescriptor) {
 		logger.info("onDeviceDeathComplete from {}...", deviceDescriptor);
 	}
 
 	@Override
-	public void onBirthMetric(SparkplugDescriptor sparkplugDescriptor, Metric metric) {
+	public void onBirthMetric(MqttServerName serverName, SparkplugDescriptor sparkplugDescriptor, Metric metric) {
 		logger.info("onBirthMetric from {} with metric={}...", sparkplugDescriptor, metric);
 	}
 
 	@Override
-	public void onDataMetric(SparkplugDescriptor sparkplugDescriptor, Metric metric) {
+	public void onDataMetric(MqttServerName serverName, SparkplugDescriptor sparkplugDescriptor, Metric metric) {
 		logger.info("onDataMetric from {} with metric={}...", sparkplugDescriptor, metric);
 	}
 
-	public void onStale(SparkplugDescriptor sparkplugDescriptor, Metric metric) {
+	public void onStale(MqttServerName serverName, SparkplugDescriptor sparkplugDescriptor, Metric metric) {
 		logger.info("onStale from {} for {}...", sparkplugDescriptor, metric.getName());
 	}
 
 	@Override
-	public void onMessage(SparkplugDescriptor sparkplugDescriptor, Message message) {
+	public void onMessage(MqttServerName serverName, SparkplugDescriptor sparkplugDescriptor, Message message) {
 		logger.info("onMessage from {} with message={}...", sparkplugDescriptor, message);
 	}
 }

--- a/java/lib/host/src/main/java/org/eclipse/tahu/host/HostApplication.java
+++ b/java/lib/host/src/main/java/org/eclipse/tahu/host/HostApplication.java
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2022 Cirrus Link Solutions and others
+ * Copyright (c) 2022-2025 Cirrus Link Solutions and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -19,7 +19,7 @@ import java.util.Map;
 
 import org.eclipse.tahu.exception.TahuErrorCode;
 import org.eclipse.tahu.exception.TahuException;
-import org.eclipse.tahu.host.api.HostApplicationEventHandler;
+import org.eclipse.tahu.host.api.MultiHostApplicationEventHandler;
 import org.eclipse.tahu.host.seq.SequenceReorderManager;
 import org.eclipse.tahu.message.PayloadDecoder;
 import org.eclipse.tahu.message.SparkplugBPayloadEncoder;
@@ -48,9 +48,10 @@ public class HostApplication implements CommandPublisher {
 	private final List<MqttServerDefinition> mqttServerDefinitions;
 	private final Map<MqttServerName, TahuClient> tahuClients = new HashMap<>();
 
-	public HostApplication(HostApplicationEventHandler eventHandler, String hostId, List<String> sparkplugSubscriptons,
-			List<MqttServerDefinition> mqttServerDefinitions, RandomStartupDelay randomStartupDelay,
-			PayloadDecoder<SparkplugBPayload> payloadDecoder, boolean onlineState) {
+	public HostApplication(MultiHostApplicationEventHandler eventHandler, String hostId,
+			List<String> sparkplugSubscriptons, List<MqttServerDefinition> mqttServerDefinitions,
+			RandomStartupDelay randomStartupDelay, PayloadDecoder<SparkplugBPayload> payloadDecoder,
+			boolean onlineState) {
 		logger.info("Creating the Host Application");
 
 		if (hostId != null) {
@@ -70,9 +71,9 @@ public class HostApplication implements CommandPublisher {
 				new TahuHostCallback(eventHandler, this, sequenceReorderManager, payloadDecoder, hostId, onlineState);
 	}
 
-	public HostApplication(HostApplicationEventHandler eventHandler, String hostId, List<String> sparkplugSubscriptons,
-			TahuHostCallback tahuHostCallback, Map<MqttServerName, TahuClient> tahuClients,
-			RandomStartupDelay randomStartupDelay) {
+	public HostApplication(MultiHostApplicationEventHandler eventHandler, String hostId,
+			List<String> sparkplugSubscriptons, TahuHostCallback tahuHostCallback,
+			Map<MqttServerName, TahuClient> tahuClients, RandomStartupDelay randomStartupDelay) {
 		logger.info("Creating the Host Application");
 
 		if (hostId != null && !hostId.trim().isEmpty()) {

--- a/java/lib/host/src/main/java/org/eclipse/tahu/host/TahuHostCallback.java
+++ b/java/lib/host/src/main/java/org/eclipse/tahu/host/TahuHostCallback.java
@@ -22,7 +22,7 @@ import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
 import org.eclipse.paho.client.mqttv3.MqttMessage;
-import org.eclipse.tahu.host.api.HostApplicationEventHandler;
+import org.eclipse.tahu.host.api.MultiHostApplicationEventHandler;
 import org.eclipse.tahu.host.seq.SequenceReorderManager;
 import org.eclipse.tahu.message.PayloadDecoder;
 import org.eclipse.tahu.message.model.SparkplugBPayload;
@@ -51,7 +51,7 @@ public class TahuHostCallback implements ClientCallback {
 
 	private final boolean enableSequenceReordering;
 
-	private final HostApplicationEventHandler eventHandler;
+	private final MultiHostApplicationEventHandler eventHandler;
 
 	private final CommandPublisher commandPublisher;
 
@@ -63,7 +63,7 @@ public class TahuHostCallback implements ClientCallback {
 
 	private boolean onlineState;
 
-	public TahuHostCallback(HostApplicationEventHandler eventHandler, CommandPublisher commandPublisher,
+	public TahuHostCallback(MultiHostApplicationEventHandler eventHandler, CommandPublisher commandPublisher,
 			SequenceReorderManager sequenceReorderManager, PayloadDecoder<SparkplugBPayload> payloadDecoder,
 			String hostId, boolean onlineState) {
 		this.eventHandler = eventHandler;
@@ -214,7 +214,7 @@ public class TahuHostCallback implements ClientCallback {
 	public void connectionLost(MqttServerName mqttServerName, MqttServerUrl url, MqttClientId clientId,
 			Throwable cause) {
 		logger.warn("Connection Lost to - {} :: {} :: {}", mqttServerName, url, clientId);
-		eventHandler.onDisconnect();
+		eventHandler.onDisconnect(mqttServerName);
 
 		if (cause != null) {
 			// We don't need to see all of the connection lost callbacks for clients
@@ -253,7 +253,7 @@ public class TahuHostCallback implements ClientCallback {
 	public void connectComplete(boolean reconnect, MqttServerName server, MqttServerUrl url, MqttClientId clientId) {
 //		// Update the ONLINE Engine Info tag for the client
 //		updateEngineInfoDateTag(server, DATE_ONLINE);
-		eventHandler.onConnect();
+		eventHandler.onConnect(server);
 	}
 
 	private void updateEngineInfoDateTag(MqttServerName server, String tagName) {

--- a/java/lib/host/src/main/java/org/eclipse/tahu/host/TahuPayloadHandler.java
+++ b/java/lib/host/src/main/java/org/eclipse/tahu/host/TahuPayloadHandler.java
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2022 Cirrus Link Solutions and others
+ * Copyright (c) 2022-2025 Cirrus Link Solutions and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -24,7 +24,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import org.eclipse.paho.client.mqttv3.MqttMessage;
 import org.eclipse.tahu.exception.TahuErrorCode;
 import org.eclipse.tahu.exception.TahuException;
-import org.eclipse.tahu.host.api.HostApplicationEventHandler;
+import org.eclipse.tahu.host.api.MultiHostApplicationEventHandler;
 import org.eclipse.tahu.host.manager.EdgeNodeManager;
 import org.eclipse.tahu.host.manager.MetricManager;
 import org.eclipse.tahu.host.manager.SparkplugDevice;
@@ -55,13 +55,13 @@ public class TahuPayloadHandler {
 
 	private static Map<EdgeNodeDescriptor, Timer> rebirthTimers = new ConcurrentHashMap<>();
 
-	private final HostApplicationEventHandler eventHandler;
+	private final MultiHostApplicationEventHandler eventHandler;
 
 	private final CommandPublisher commandPublisher;
 
 	private final PayloadDecoder<SparkplugBPayload> payloadDecoder;
 
-	public TahuPayloadHandler(HostApplicationEventHandler eventHandler, CommandPublisher commandPublisher,
+	public TahuPayloadHandler(MultiHostApplicationEventHandler eventHandler, CommandPublisher commandPublisher,
 			PayloadDecoder<SparkplugBPayload> payloadDecoder) {
 		this.eventHandler = eventHandler;
 		this.commandPublisher = commandPublisher;
@@ -129,27 +129,27 @@ public class TahuPayloadHandler {
 			switch (type) {
 				case NBIRTH:
 					logger.info("Handling NBIRTH from {}", topic.getSparkplugDescriptor());
-					handleNodeBirth(messageContext);
+					handleNodeBirth(mqttServerName, messageContext);
 					break;
 				case DBIRTH:
 					logger.info("Handling DBIRTH from {}", topic.getSparkplugDescriptor());
-					handleDeviceBirth(messageContext);
+					handleDeviceBirth(mqttServerName, messageContext);
 					break;
 				case NDATA:
 					logger.info("Handling NDATA from {}", topic.getSparkplugDescriptor());
-					handleNodeData(messageContext);
+					handleNodeData(mqttServerName, messageContext);
 					break;
 				case DDATA:
 					logger.info("Handling DDATA from {}", topic.getSparkplugDescriptor());
-					handleDeviceData(messageContext);
+					handleDeviceData(mqttServerName, messageContext);
 					break;
 				case NDEATH:
 					logger.info("Handling NDEATH from {}", topic.getSparkplugDescriptor());
-					handleNodeDeath(messageContext);
+					handleNodeDeath(mqttServerName, messageContext);
 					break;
 				case DDEATH:
 					logger.info("Handling DDEATH from {}", topic.getSparkplugDescriptor());
-					handleDeviceDeath(messageContext);
+					handleDeviceDeath(mqttServerName, messageContext);
 					break;
 
 				default:
@@ -161,7 +161,7 @@ public class TahuPayloadHandler {
 		}
 	}
 
-	protected void handleNodeBirth(MessageContext messageContext) throws Exception {
+	protected void handleNodeBirth(MqttServerName mqttServerName, MessageContext messageContext) throws Exception {
 		logger.debug("Processing NBIRTH from Edge Node {} with Seq# {}",
 				messageContext.getTopic().getEdgeNodeDescriptor(), messageContext.getSeqNum());
 		EdgeNodeDescriptor edgeNodeDescriptor = messageContext.getTopic().getEdgeNodeDescriptor();
@@ -183,8 +183,8 @@ public class TahuPayloadHandler {
 		sparkplugEdgeNode.setOnline(true, messageContext.getPayload().getTimestamp(),
 				SparkplugUtil.getBdSequenceNumber(messageContext.getPayload()), messageContext.getSeqNum());
 
-		eventHandler.onNodeBirthArrived(edgeNodeDescriptor, messageContext.getMessage());
-		eventHandler.onMessage(edgeNodeDescriptor, messageContext.getMessage());
+		eventHandler.onNodeBirthArrived(mqttServerName, edgeNodeDescriptor, messageContext.getMessage());
+		eventHandler.onMessage(mqttServerName, edgeNodeDescriptor, messageContext.getMessage());
 		for (Metric metric : messageContext.getPayload().getMetrics()) {
 			if (metric.hasAlias()) {
 				// Make sure the alias doesn't already exist
@@ -206,12 +206,12 @@ public class TahuPayloadHandler {
 
 			// Update the cache and notify
 			sparkplugEdgeNode.putMetric(metric.getName(), new HostMetric(metric, false));
-			eventHandler.onBirthMetric(edgeNodeDescriptor, metric);
+			eventHandler.onBirthMetric(mqttServerName, edgeNodeDescriptor, metric);
 		}
-		eventHandler.onNodeBirthComplete(edgeNodeDescriptor);
+		eventHandler.onNodeBirthComplete(mqttServerName, edgeNodeDescriptor);
 	}
 
-	protected void handleDeviceBirth(MessageContext messageContext) throws Exception {
+	protected void handleDeviceBirth(MqttServerName mqttServerName, MessageContext messageContext) throws Exception {
 		logger.debug("Processing DBIRTH from Device {} with Seq# {}",
 				messageContext.getTopic().getSparkplugDescriptor(), messageContext.getSeqNum());
 		EdgeNodeDescriptor edgeNodeDescriptor = messageContext.getTopic().getEdgeNodeDescriptor();
@@ -231,8 +231,8 @@ public class TahuPayloadHandler {
 		// Set online
 		sparkplugDevice.setOnline(true, messageContext.getPayload().getTimestamp());
 
-		eventHandler.onDeviceBirthArrived(deviceDescriptor, messageContext.getMessage());
-		eventHandler.onMessage(deviceDescriptor, messageContext.getMessage());
+		eventHandler.onDeviceBirthArrived(mqttServerName, deviceDescriptor, messageContext.getMessage());
+		eventHandler.onMessage(mqttServerName, deviceDescriptor, messageContext.getMessage());
 		HostApplicationMetricMap hostApplicationMetricMap = HostApplicationMetricMap.getInstance();
 		for (Metric metric : messageContext.getPayload().getMetrics()) {
 			if (metric.hasAlias()) {
@@ -253,12 +253,12 @@ public class TahuPayloadHandler {
 
 			// Update the cache and notify
 			sparkplugDevice.putMetric(metric.getName(), new HostMetric(metric, false));
-			eventHandler.onBirthMetric(deviceDescriptor, metric);
+			eventHandler.onBirthMetric(mqttServerName, deviceDescriptor, metric);
 		}
-		eventHandler.onDeviceBirthComplete(deviceDescriptor);
+		eventHandler.onDeviceBirthComplete(mqttServerName, deviceDescriptor);
 	}
 
-	protected void handleNodeData(MessageContext messageContext) throws Exception {
+	protected void handleNodeData(MqttServerName mqttServerName, MessageContext messageContext) throws Exception {
 		logger.debug("Processing NDATA from Edge Node {} with Seq# {}",
 				messageContext.getTopic().getEdgeNodeDescriptor(), messageContext.getSeqNum());
 		EdgeNodeDescriptor edgeNodeDescriptor = messageContext.getTopic().getEdgeNodeDescriptor();
@@ -274,8 +274,8 @@ public class TahuPayloadHandler {
 
 		sparkplugEdgeNode.handleSeq(messageContext.getPayload().getSeq());
 
-		eventHandler.onNodeDataArrived(edgeNodeDescriptor, messageContext.getMessage());
-		eventHandler.onMessage(edgeNodeDescriptor, messageContext.getMessage());
+		eventHandler.onNodeDataArrived(mqttServerName, edgeNodeDescriptor, messageContext.getMessage());
+		eventHandler.onMessage(mqttServerName, edgeNodeDescriptor, messageContext.getMessage());
 		for (Metric metric : messageContext.getPayload().getMetrics()) {
 			if (!metric.hasName() && metric.hasAlias()) {
 				metric.setName(HostApplicationMetricMap.getInstance().getMetricName(edgeNodeDescriptor,
@@ -284,12 +284,12 @@ public class TahuPayloadHandler {
 
 			// Update the metric in the cache and notify
 			sparkplugEdgeNode.updateValue(metric.getName(), metric.getValue());
-			eventHandler.onDataMetric(edgeNodeDescriptor, metric);
+			eventHandler.onDataMetric(mqttServerName, edgeNodeDescriptor, metric);
 		}
-		eventHandler.onNodeDataArrived(edgeNodeDescriptor, messageContext.getMessage());
+		eventHandler.onNodeDataArrived(mqttServerName, edgeNodeDescriptor, messageContext.getMessage());
 	}
 
-	protected void handleDeviceData(MessageContext messageContext) throws Exception {
+	protected void handleDeviceData(MqttServerName mqttServerName, MessageContext messageContext) throws Exception {
 		logger.debug("Processing DDATA from Device {} with Seq# {}", messageContext.getTopic().getSparkplugDescriptor(),
 				messageContext.getSeqNum());
 		EdgeNodeDescriptor edgeNodeDescriptor = messageContext.getTopic().getEdgeNodeDescriptor();
@@ -307,8 +307,8 @@ public class TahuPayloadHandler {
 
 		sparkplugEdgeNode.handleSeq(messageContext.getPayload().getSeq());
 
-		eventHandler.onDeviceDataArrived(deviceDescriptor, messageContext.getMessage());
-		eventHandler.onMessage(deviceDescriptor, messageContext.getMessage());
+		eventHandler.onDeviceDataArrived(mqttServerName, deviceDescriptor, messageContext.getMessage());
+		eventHandler.onMessage(mqttServerName, deviceDescriptor, messageContext.getMessage());
 		for (Metric metric : messageContext.getPayload().getMetrics()) {
 			if (!metric.hasName() && metric.hasAlias()) {
 				metric.setName(HostApplicationMetricMap.getInstance().getMetricName(edgeNodeDescriptor,
@@ -317,12 +317,12 @@ public class TahuPayloadHandler {
 
 			// Update the metric in the cache and notify
 			sparkplugDevice.updateValue(metric.getName(), metric.getValue());
-			eventHandler.onDataMetric(deviceDescriptor, metric);
+			eventHandler.onDataMetric(mqttServerName, deviceDescriptor, metric);
 		}
-		eventHandler.onDeviceDataComplete(deviceDescriptor);
+		eventHandler.onDeviceDataComplete(mqttServerName, deviceDescriptor);
 	}
 
-	protected void handleNodeDeath(MessageContext messageContext) {
+	protected void handleNodeDeath(MqttServerName mqttServerName, MessageContext messageContext) {
 		Long incomingBdSeqNum = -1L;
 		EdgeNodeDescriptor edgeNodeDescriptor = messageContext.getTopic().getEdgeNodeDescriptor();
 		try {
@@ -333,16 +333,16 @@ public class TahuPayloadHandler {
 				if (sparkplugEdgeNode.isOnline()) {
 					long birthBdSeqNum = sparkplugEdgeNode.getBirthBdSeqNum();
 					if (birthBdSeqNum == incomingBdSeqNum) {
-						eventHandler.onNodeDeath(edgeNodeDescriptor, messageContext.getMessage());
-						eventHandler.onMessage(edgeNodeDescriptor, messageContext.getMessage());
-						staleTags(edgeNodeDescriptor, sparkplugEdgeNode);
+						eventHandler.onNodeDeath(mqttServerName, edgeNodeDescriptor, messageContext.getMessage());
+						eventHandler.onMessage(mqttServerName, edgeNodeDescriptor, messageContext.getMessage());
+						staleTags(mqttServerName, edgeNodeDescriptor, sparkplugEdgeNode);
 						sparkplugEdgeNode.setOnline(false, messageContext.getPayload().getTimestamp(), incomingBdSeqNum,
 								null);
 						for (SparkplugDevice sparkplugDevice : sparkplugEdgeNode.getSparkplugDevices().values()) {
-							staleTags(sparkplugDevice.getDeviceDescrptor(), sparkplugDevice);
+							staleTags(mqttServerName, sparkplugDevice.getDeviceDescrptor(), sparkplugDevice);
 							sparkplugDevice.setOnline(false, messageContext.getPayload().getTimestamp());
 						}
-						eventHandler.onNodeDeathComplete(edgeNodeDescriptor);
+						eventHandler.onNodeDeathComplete(mqttServerName, edgeNodeDescriptor);
 					} else {
 						logger.error(
 								"Edge Node bdSeq number mismatch on incoming NDEATH from {} - received {}, expected {} - ignoring NDEATH",
@@ -360,7 +360,8 @@ public class TahuPayloadHandler {
 		}
 	}
 
-	protected void handleDeviceDeath(MessageContext messageContext) throws TahuException {
+	protected void handleDeviceDeath(MqttServerName mqttServerName, MessageContext messageContext)
+			throws TahuException {
 		EdgeNodeDescriptor edgeNodeDescriptor = messageContext.getTopic().getEdgeNodeDescriptor();
 		DeviceDescriptor deviceDescriptor = (DeviceDescriptor) messageContext.getTopic().getSparkplugDescriptor();
 		SparkplugEdgeNode sparkplugEdgeNode = EdgeNodeManager.getInstance().getSparkplugEdgeNode(edgeNodeDescriptor);
@@ -375,11 +376,11 @@ public class TahuPayloadHandler {
 		sparkplugEdgeNode.handleSeq(messageContext.getPayload().getSeq());
 
 		if (sparkplugEdgeNode.isOnline() && sparkplugDevice.isOnline()) {
-			eventHandler.onDeviceDeath(deviceDescriptor, messageContext.getMessage());
-			eventHandler.onMessage(deviceDescriptor, messageContext.getMessage());
-			staleTags(deviceDescriptor, sparkplugDevice);
+			eventHandler.onDeviceDeath(mqttServerName, deviceDescriptor, messageContext.getMessage());
+			eventHandler.onMessage(mqttServerName, deviceDescriptor, messageContext.getMessage());
+			staleTags(mqttServerName, deviceDescriptor, sparkplugDevice);
 			sparkplugDevice.setOnline(false, messageContext.getPayload().getTimestamp());
-			eventHandler.onDeviceDeathComplete(deviceDescriptor);
+			eventHandler.onDeviceDeathComplete(mqttServerName, deviceDescriptor);
 		} else {
 			logger.error("Online requirements not met for {} - edgeNode={} and device={} - ignoring DDEATH",
 					deviceDescriptor, sparkplugEdgeNode.isOnline() ? "online" : "offline",
@@ -387,7 +388,8 @@ public class TahuPayloadHandler {
 		}
 	}
 
-	private void staleTags(SparkplugDescriptor sparkplugDescriptor, MetricManager metricManager) {
+	private void staleTags(MqttServerName mqttServerName, SparkplugDescriptor sparkplugDescriptor,
+			MetricManager metricManager) {
 		// Stale all tags associated with this Edge Node
 		Set<String> metricNames = metricManager.getMetricNames();
 		Iterator<String> it = metricNames.iterator();
@@ -396,7 +398,7 @@ public class TahuPayloadHandler {
 
 			// Update the cache and notify
 			metricManager.setStale(metricName, true);
-			eventHandler.onStale(sparkplugDescriptor, metricManager.getMetric(metricName));
+			eventHandler.onStale(mqttServerName, sparkplugDescriptor, metricManager.getMetric(metricName));
 		}
 	}
 

--- a/java/lib/host/src/main/java/org/eclipse/tahu/host/api/MultiHostApplicationEventHandler.java
+++ b/java/lib/host/src/main/java/org/eclipse/tahu/host/api/MultiHostApplicationEventHandler.java
@@ -1,0 +1,60 @@
+/********************************************************************************
+ * Copyright (c) 2025 Cirrus Link Solutions and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Cirrus Link Solutions - initial implementation
+ ********************************************************************************/
+
+package org.eclipse.tahu.host.api;
+
+import org.eclipse.tahu.message.model.DeviceDescriptor;
+import org.eclipse.tahu.message.model.EdgeNodeDescriptor;
+import org.eclipse.tahu.message.model.Message;
+import org.eclipse.tahu.message.model.Metric;
+import org.eclipse.tahu.message.model.SparkplugDescriptor;
+import org.eclipse.tahu.mqtt.MqttServerName;
+
+public interface MultiHostApplicationEventHandler {
+
+	public void onConnect(MqttServerName serverName);
+
+	public void onDisconnect(MqttServerName serverName);
+
+	public void onMessage(MqttServerName serverName, SparkplugDescriptor sparkplugDescriptor, Message message);
+
+	public void onNodeBirthArrived(MqttServerName serverName, EdgeNodeDescriptor edgeNodeDescriptor, Message message);
+
+	public void onNodeBirthComplete(MqttServerName serverName, EdgeNodeDescriptor edgeNodeDescriptor);
+
+	public void onNodeDataArrived(MqttServerName serverName, EdgeNodeDescriptor edgeNodeDescriptor, Message message);
+
+	public void onNodeDataComplete(MqttServerName serverName, EdgeNodeDescriptor edgeNodeDescriptor);
+
+	public void onNodeDeath(MqttServerName serverName, EdgeNodeDescriptor edgeNodeDescriptor, Message message);
+
+	public void onNodeDeathComplete(MqttServerName serverName, EdgeNodeDescriptor edgeNodeDescriptor);
+
+	public void onDeviceBirthArrived(MqttServerName serverName, DeviceDescriptor deviceDescriptor, Message message);
+
+	public void onDeviceBirthComplete(MqttServerName serverName, DeviceDescriptor deviceDescriptor);
+
+	public void onDeviceDataArrived(MqttServerName serverName, DeviceDescriptor deviceDescriptor, Message message);
+
+	public void onDeviceDataComplete(MqttServerName serverName, DeviceDescriptor deviceDescriptor);
+
+	public void onDeviceDeath(MqttServerName serverName, DeviceDescriptor deviceDescriptor, Message message);
+
+	public void onDeviceDeathComplete(MqttServerName serverName, DeviceDescriptor deviceDescriptor);
+
+	public void onBirthMetric(MqttServerName serverName, SparkplugDescriptor sparkplugDescriptor, Metric metric);
+
+	public void onDataMetric(MqttServerName serverName, SparkplugDescriptor sparkplugDescriptor, Metric metric);
+
+	public void onStale(MqttServerName serverName, SparkplugDescriptor sparkplugDescriptor, Metric metric);
+}

--- a/java/lib/host/src/main/java/org/eclipse/tahu/host/seq/SequenceReorderManager.java
+++ b/java/lib/host/src/main/java/org/eclipse/tahu/host/seq/SequenceReorderManager.java
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2022 Cirrus Link Solutions and others
+ * Copyright (c) 2022-2025 Cirrus Link Solutions and others
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -25,7 +25,7 @@ import org.eclipse.tahu.SparkplugParsingException;
 import org.eclipse.tahu.host.CommandPublisher;
 import org.eclipse.tahu.host.TahuHostCallback;
 import org.eclipse.tahu.host.TahuPayloadHandler;
-import org.eclipse.tahu.host.api.HostApplicationEventHandler;
+import org.eclipse.tahu.host.api.MultiHostApplicationEventHandler;
 import org.eclipse.tahu.host.manager.EdgeNodeManager;
 import org.eclipse.tahu.host.manager.SparkplugEdgeNode;
 import org.eclipse.tahu.host.model.HostApplicationMetricMap;
@@ -54,7 +54,7 @@ public class SequenceReorderManager {
 
 	private Timer timer;
 
-	private HostApplicationEventHandler eventHandler;
+	private MultiHostApplicationEventHandler eventHandler;
 
 	private CommandPublisher commandPublisher;
 
@@ -62,7 +62,7 @@ public class SequenceReorderManager {
 
 	private Long timeout;
 
-	private SequenceReorderManager() {
+	public SequenceReorderManager() {
 		this.edgeNodeMap = new ConcurrentHashMap<>();
 	}
 
@@ -73,13 +73,13 @@ public class SequenceReorderManager {
 		return instance;
 	}
 
-	public void init(HostApplicationEventHandler eventHandler, CommandPublisher commandPublisher,
+	public void init(MultiHostApplicationEventHandler eventHandler, CommandPublisher commandPublisher,
 			PayloadDecoder<SparkplugBPayload> payloadDecoder, Long timeout) {
 		if (eventHandler != null && timeout != null) {
-			instance.eventHandler = eventHandler;
-			instance.commandPublisher = commandPublisher;
-			instance.payloadDecoder = payloadDecoder;
-			instance.timeout = timeout;
+			this.eventHandler = eventHandler;
+			this.commandPublisher = commandPublisher;
+			this.payloadDecoder = payloadDecoder;
+			this.timeout = timeout;
 		} else {
 			logger.error("Not re-initializing the SequenceReorderManager timer");
 		}


### PR DESCRIPTION
- Created a `MultiHostApplicationEventHandler` interface to pass along the `MqttServerName` corresponding to the event.
- Replaced `HostApplicationEventHandler` usage with `MultiHostApplicationEventHandler` in the `SparkplugHostApplication` to support multiple MQTT servers
- Made `SequenceReorderManager` constructor public