### PR TITLE
Fix Issue #323: Allow disabling SPARKPLUG_DEBUG using compile flags

### DIFF
--- a/c/core/include/tahu.h
+++ b/c/core/include/tahu.h
@@ -29,9 +29,11 @@ extern "C" {
 #endif
 
 // Enable/disable debug messages
+#ifndef SPARKPLUG_DEBUG 
 #define SPARKPLUG_DEBUG 1
+#endif
 
-#ifdef SPARKPLUG_DEBUG
+#if SPARKPLUG_DEBUG
 #define DEBUG_PRINT(...) printf(__VA_ARGS__)
 #else
 #define DEBUG_PRINT(...) do {} while (0)

--- a/c/core/src/tahu.c
+++ b/c/core/src/tahu.c
@@ -320,7 +320,7 @@ ssize_t decode_payload(org_eclipse_tahu_protobuf_Payload *payload,
         return -1;
     }
 
-#ifdef SPARKPLUG_DEBUG
+#if SPARKPLUG_DEBUG
     // Print the message data
     print_payload(payload);
 #endif

--- a/c/core/test/test.c
+++ b/c/core/test/test.c
@@ -500,7 +500,7 @@ void publish_node_birth(struct mosquitto *mosq) {
     // Add the UDT to the payload
     add_metric_to_payload(&nbirth_payload, &metric);
 
-#ifdef SPARKPLUG_DEBUG
+#if SPARKPLUG_DEBUG
     // Print the payload for debug
     print_payload(&nbirth_payload);
 #endif
@@ -591,7 +591,7 @@ void publish_device_birth(struct mosquitto *mosq) {
     // Add the UDT Instance to the payload
     add_metric_to_payload(&dbirth_payload, &metric);
 
-#ifdef SPARKPLUG_DEBUG
+#if SPARKPLUG_DEBUG
     // Print the payload
     print_payload(&dbirth_payload);
 #endif
@@ -638,7 +638,7 @@ void publish_ddata_message(struct mosquitto *mosq) {
     float ddata_metric_float_value = ((float)rand() / (float)(RAND_MAX)) * 5.0;
     add_simple_metric(&ddata_payload, NULL, true, ALIAS_DEVICE_METRIC_FLOAT, METRIC_DATA_TYPE_FLOAT, false, false, &ddata_metric_float_value, sizeof(ddata_metric_float_value));
 
-#ifdef SPARKPLUG_DEBUG
+#if SPARKPLUG_DEBUG
     // Print the payload
     print_payload(&ddata_payload);
 #endif

--- a/c/examples/template_as_custom_props/example.c
+++ b/c/examples/template_as_custom_props/example.c
@@ -288,7 +288,7 @@ void publish_node_birth(struct mosquitto *mosq) {
     // Add the Template to the payload
     add_metric_to_payload(&nbirth_payload, &metric);
 
-#ifdef SPARKPLUG_DEBUG
+#if SPARKPLUG_DEBUG
     // Print the payload for debug
     print_payload(&nbirth_payload);
 #endif
@@ -371,7 +371,7 @@ void publish_device_birth(struct mosquitto *mosq) {
     // Add the Template Instance to the payload
     add_metric_to_payload(&dbirth_payload, &metric);
 
-#ifdef SPARKPLUG_DEBUG
+#if SPARKPLUG_DEBUG
     // Print the payload
     print_payload(&dbirth_payload);
 #endif
@@ -415,7 +415,7 @@ void publish_ddata_message(struct mosquitto *mosq) {
 
     add_metric_to_payload(&ddata_payload, &metric);
 
-#ifdef SPARKPLUG_DEBUG
+#if SPARKPLUG_DEBUG
     // Print the payload
     print_payload(&ddata_payload);
 #endif

--- a/c/examples/udt_example/example.c
+++ b/c/examples/udt_example/example.c
@@ -470,7 +470,7 @@ void publish_node_birth(struct mosquitto *mosq) {
     // Add the UDT to the payload
     add_metric_to_payload(&nbirth_payload, &metric);
 
-#ifdef SPARKPLUG_DEBUG
+#if SPARKPLUG_DEBUG
     // Print the payload for debug
     print_payload(&nbirth_payload);
 #endif
@@ -551,7 +551,7 @@ void publish_device_birth(struct mosquitto *mosq) {
     // Add the UDT Instance to the payload
     add_metric_to_payload(&dbirth_payload, &metric);
 
-#ifdef SPARKPLUG_DEBUG
+#if SPARKPLUG_DEBUG
     // Print the payload
     print_payload(&dbirth_payload);
 #endif
@@ -591,7 +591,7 @@ void publish_ddata_message(struct mosquitto *mosq) {
     // Note the Metric name 'input/Device Metric1' is not needed because we're using aliases
     add_simple_metric(&ddata_payload, NULL, true, Device_Metric1, METRIC_DATA_TYPE_BOOLEAN, false, false, &ddata_metric_one_value, sizeof(ddata_metric_one_value));
 
-#ifdef SPARKPLUG_DEBUG
+#if SPARKPLUG_DEBUG
     // Print the payload
     print_payload(&ddata_payload);
 #endif


### PR DESCRIPTION
Proposing fix for https://github.com/eclipse-tahu/tahu/issues/323.

This change allows to disable SPARKPLUG_DEBUG through compile flag. Otherwise if we want to disable the Debug we have to change the source code and this implies in "Modified Work" according to EPL 2.0 license.