### PR TITLE
Add Command and Status messages to sparkplug_c.proto (typed commands + request/response)

### DIFF
--- a/sparkplug_c/sparkplug_c.proto
+++ b/sparkplug_c/sparkplug_c.proto
@@ -66,6 +66,9 @@ enum DataType {
     BOOLEAN_ARRAY = 32;
     STRING_ARRAY = 33;
     DATE_TIME_ARRAY = 34;
+
+    // Command Type
+    COMMAND         = 35;        // A callable command/function metric - the value is carried in the Metric 'command' field rather than 'value'
 }
 
 message Payload {
@@ -112,6 +115,33 @@ message Payload {
         string template_ref  = 4;          // MUST be a reference to a template definition if this is an instance (i.e. the name of the template definition) - MUST be omitted for template definitions
         bool is_definition   = 5;
         extensions                      6 to max;
+    }
+
+    message Status {
+        uint64 code    = 1;                // Result code of a command invocation - 0 indicates success, any non-zero value indicates an error
+        string message = 2;                // Optional human readable status/error description
+        extensions                      3 to max;
+    }
+
+    message Command {
+
+        // Input argument definitions (in NBIRTH/DBIRTH) or supplied argument values (in NCMD/DCMD requests).
+        // Each argument is a full Metric so it can carry a name, datatype, properties, metadata, and may itself
+        // be a Template instance for structured/complex arguments. Omitted for commands that accept no inputs.
+        repeated Metric arguments     = 1 [features.repeated_field_encoding = EXPANDED];
+
+        // Result/output argument definitions (in NBIRTH/DBIRTH) or returned result values (in NRESP/DRESP responses).
+        // Omitted for commands that return no outputs.
+        repeated Metric results       = 2 [features.repeated_field_encoding = EXPANDED];
+
+        // Correlation identifier set on an NCMD/DCMD request and echoed unchanged in the corresponding
+        // NRESP/DRESP response so a Host Application can match the response to the request that produced it.
+        string correlation_id = 3;
+
+        // Execution status - present in NRESP/DRESP responses, omitted in BIRTH definitions and CMD requests.
+        Status status         = 4;
+
+        extensions                      5 to max;
     }
 
     message DataSet {
@@ -181,7 +211,8 @@ message Payload {
         MetaData metadata      = 9;        // Metadata for the Metric
         PropertySet properties = 10;       // Properties of the Metric
         TypedValue value       = 11;
-        extensions 12 to max;
+        Command  command       = 12;       // Command definition (BIRTH), invocation (CMD), or response (RESP) - present when datatype == COMMAND instead of 'value'
+        extensions 13 to max;
     }
 
     uint64   timestamp     = 1;        // Timestamp at message sending time


### PR DESCRIPTION
  Companion to eclipse-sparkplug/sparkplug (https://github.com/eclipse-sparkplug/sparkplug/pull/615) — relates to:
  Sparkplug [#441](https://github.com/eclipse-sparkplug/sparkplug/issues/441) and [#442](https://github.com/eclipse-sparkplug/sparkplug/issues/441)

  **Summary**

  Extends the Sparkplug C protobuf schema to support strongly typed, invocable Commands with a correlated request/response lifecycle. This is the wire-format counterpart to the specification changes that define typed command signatures
  (BIRTH), command invocation (NCMD/DCMD), and command responses (NRESP/DRESP).

  Scope is intentionally narrow: only sparkplug_c/sparkplug_c.proto (+32/−1).

  **Changes**
  
  1. New DataType enum value — COMMAND = 35 (appended after DATE_TIME_ARRAY = 34). A metric of this datatype carries its content in the new command field instead of value.
  2. New Command message (nested in Payload):
    - repeated Metric arguments — input argument definitions (in NBIRTH/DBIRTH) or supplied values (in NCMD/DCMD). Each argument is a full Metric, so structured/complex inputs reuse Template instances.
    - repeated Metric results — output definitions (BIRTH) or returned values (NRESP/DRESP).
    - string correlation_id — set on a request, echoed unchanged in the response so a Host can match the two.
    - Status status — present in responses; omitted in BIRTH definitions and requests.
  3. New Status message (nested in Payload):
    - uint64 code — 0 = success, non-zero = error.
    - string message — optional human-readable description.
  4. Metric.command field — Command command = 12; added; extensions bumped 12 → 13.

  The single message shape serves three roles, distinguished by which fields are set: definition (BIRTH), request (NCMD/DCMD), response (NRESP/DRESP).

  **Compatibility & schema safety**

  - All additions use previously unused field numbers — Metric.command = 12 sits in the old extensions 12 to max range (now 13 to max); Command/Status fields and the COMMAND = 35 enum value are all new. No existing field numbers or tags
  change, so this is wire-compatible at the protobuf level.
  - Style matches the surrounding file: Edition 2024 syntax, extensions N to max on each message, and [features.repeated_field_encoding = EXPANDED] on the repeated Metric fields (consistent with Template).
  - This targets the Sparkplug C schema (spCv1.0); sparkplug_b.proto is untouched.

  **Testing**

  Manual review confirms: COMMAND = 35 is unique in the enum; Metric field numbers are contiguous (…value = 11, command = 12, extensions 13 to max); Command/Status field numbers are sequential with no overlap.

  **Notes for reviewers**

  - The working tree contains other unrelated, unstaged modifications (pom.xml, TahuClient.java, sparkplug_b*.proto) — these are not part of this commit, which stages only sparkplug_c.proto.
  - The companion spec PR adds the normative Command/Status/NRESP/DRESP definitions and the embedded .proto listing (proto2-style); the two proto representations have pre-existing drift (the spec listing carries quality/quality_context fields
  this file does not) that is out of scope here.