### PR TITLE
Add opt-in ObjectMapper reuse and a toMap() converter to PayloadUtil

### DIFF
--- a/java/lib/core/src/main/java/org/eclipse/tahu/util/PayloadUtil.java
+++ b/java/lib/core/src/main/java/org/eclipse/tahu/util/PayloadUtil.java
@@ -16,6 +16,7 @@ package org.eclipse.tahu.util;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 import java.util.zip.DataFormatException;
 import java.util.zip.Deflater;
 import java.util.zip.Inflater;
@@ -36,6 +37,7 @@ import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -51,30 +53,99 @@ public class PayloadUtil {
 	public static final String METRIC_ALGORITHM = "algorithm";
 
 	/**
+	 * A shared, pre-configured mapper reused when callers opt in via the useCachedMapper flag. Building and
+	 * configuring an ObjectMapper is expensive; reusing one avoids that per-call cost on hot paths. ObjectMapper is
+	 * thread-safe once configured, and DeserializerModule/DeserializerModifier are safe to register once and reuse.
+	 */
+	private static final ObjectMapper CACHED_MAPPER =
+			new ObjectMapper().registerModule(new DeserializerModule(new DeserializerModifier()));
+
+	/**
 	 * Serializes a {@link SparkplugBPayload} instance in to a JSON string.
-	 * 
+	 *
 	 * @param payload a {@link SparkplugBPayload} instance
 	 * @return a JSON string
 	 * @throws JsonProcessingException
 	 */
 	public static String toJsonString(SparkplugBPayload payload) throws JsonProcessingException {
-		ObjectMapper mapper = new ObjectMapper();
-		mapper.registerModule(new DeserializerModule(new DeserializerModifier()));
-		return mapper.writeValueAsString(payload);
+		return toJsonString(payload, false);
+	}
+
+	/**
+	 * Serializes a {@link SparkplugBPayload} instance in to a JSON string.
+	 *
+	 * @param payload a {@link SparkplugBPayload} instance
+	 * @param useCachedMapper if true, reuse a shared pre-configured {@link ObjectMapper} instead of creating a new
+	 *            one per call (faster on hot paths)
+	 * @return a JSON string
+	 * @throws JsonProcessingException
+	 */
+	public static String toJsonString(SparkplugBPayload payload, boolean useCachedMapper)
+			throws JsonProcessingException {
+		return getMapper(useCachedMapper).writeValueAsString(payload);
+	}
+
+	/**
+	 * Converts a {@link SparkplugBPayload} instance into a structured {@link Map} (nested Maps/Lists/primitives)
+	 * matching the JSON representation. Useful for consumers that need the payload as a native object graph rather
+	 * than a JSON string (e.g. inserting into a semi-structured column) - producing the Map directly avoids the
+	 * serialize-to-string-then-reparse round trip.
+	 *
+	 * @param payload a {@link SparkplugBPayload} instance
+	 * @return the payload as a {@link Map} of String to Object
+	 */
+	public static Map<String, Object> toMap(SparkplugBPayload payload) {
+		return toMap(payload, false);
+	}
+
+	/**
+	 * Converts a {@link SparkplugBPayload} instance into a structured {@link Map} (nested Maps/Lists/primitives)
+	 * matching the JSON representation.
+	 *
+	 * @param payload a {@link SparkplugBPayload} instance
+	 * @param useCachedMapper if true, reuse a shared pre-configured {@link ObjectMapper} instead of creating a new
+	 *            one per call (faster on hot paths)
+	 * @return the payload as a {@link Map} of String to Object
+	 */
+	public static Map<String, Object> toMap(SparkplugBPayload payload, boolean useCachedMapper) {
+		return getMapper(useCachedMapper).convertValue(payload, new TypeReference<Map<String, Object>>() {
+		});
 	}
 
 	/**
 	 * Deserializes a JSON string into a {@link SparkplugBPayload} instance.
-	 * 
+	 *
 	 * @param payload a JSON string
 	 * @return a {@link SparkplugBPayload} instance
 	 * @throws JsonProcessingException
 	 */
 	public static SparkplugBPayload fromJsonString(String jsonString)
 			throws JsonParseException, JsonMappingException, IOException {
-		ObjectMapper mapper = new ObjectMapper();
-		mapper.registerModule(new DeserializerModule(new DeserializerModifier()));
-		return mapper.readValue(jsonString, SparkplugBPayload.class);
+		return fromJsonString(jsonString, false);
+	}
+
+	/**
+	 * Deserializes a JSON string into a {@link SparkplugBPayload} instance.
+	 *
+	 * @param payload a JSON string
+	 * @param useCachedMapper if true, reuse a shared pre-configured {@link ObjectMapper} instead of creating a new
+	 *            one per call (faster on hot paths)
+	 * @return a {@link SparkplugBPayload} instance
+	 * @throws JsonProcessingException
+	 */
+	public static SparkplugBPayload fromJsonString(String jsonString, boolean useCachedMapper)
+			throws JsonParseException, JsonMappingException, IOException {
+		return getMapper(useCachedMapper).readValue(jsonString, SparkplugBPayload.class);
+	}
+
+	/*
+	 * Returns the shared cached mapper when useCachedMapper is true, otherwise a new per-call mapper (preserving the
+	 * original behavior for existing callers).
+	 */
+	private static ObjectMapper getMapper(boolean useCachedMapper) {
+		return useCachedMapper
+				? CACHED_MAPPER
+				: new ObjectMapper().registerModule(new DeserializerModule(new DeserializerModifier()));
 	}
 
 	/**


### PR DESCRIPTION
# PayloadUtil: optional mapper reuse + toMap() conversion

**Module:** `tahu-core` · `org.eclipse.tahu.util.PayloadUtil` · 1 file changed

**Title:** `Add opt-in ObjectMapper reuse and a toMap() converter to PayloadUtil`

**Description:**

> `PayloadUtil.toJsonString`/`fromJsonString` construct and configure a new `ObjectMapper` (including module registration) on every call. Building an `ObjectMapper` is comparatively expensive, so this is wasteful on hot paths that (de)serialize many payloads. This adds opt-in overloads that reuse a shared, pre-configured mapper, and a new `toMap(...)` that converts a payload straight to a native `Map` object graph without a serialize-to-string-then-reparse round trip. All existing method signatures and their behavior are unchanged, so current callers are unaffected.

## Changes

- **Shared cached mapper.** New `private static final ObjectMapper CACHED_MAPPER`, pre-configured once with the existing `DeserializerModule`/`DeserializerModifier`. `ObjectMapper` is thread-safe once configured, and the module/modifier are safe to register once and reuse.
- **Opt-in overloads (backwards compatible).**
  - `toJsonString(SparkplugBPayload, boolean useCachedMapper)`
  - `fromJsonString(String, boolean useCachedMapper)`
  - The existing no-flag `toJsonString(...)` / `fromJsonString(...)` now delegate with `false`, preserving their original per-call-mapper behavior exactly.
- **New `toMap(...)`.**
  - `toMap(SparkplugBPayload)` and `toMap(SparkplugBPayload, boolean useCachedMapper)` return the payload as a structured `Map<String, Object>` (nested Maps/Lists/primitives) via `ObjectMapper.convertValue(...)`. This is for consumers that need a native object graph rather than a JSON string, and it avoids materializing an intermediate JSON string and re-parsing it.
- **Private helper** `getMapper(boolean useCachedMapper)` returns the shared mapper when `true`, otherwise a freshly configured one (the original behavior).

## Compatibility

- Purely additive. No existing method signature or default behavior changes; callers that don't pass the flag get identical results to before.
- `useCachedMapper = true` opts into the shared mapper for callers on performance-sensitive paths.

## Testing

`PayloadUtil`'s existing round-trip tests continue to pass. Manually verified that `toJsonString(payload, true)` produces output identical to `toJsonString(payload)`, that `fromJsonString` round-trips, and that `toMap(payload, true)` yields a `Map` structurally equivalent to parsing `toJsonString(payload)`.